### PR TITLE
chore: upgrade node version in publish packages job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'yarn'
 
       - name: Set Git Config


### PR DESCRIPTION
Upgrade node version in publish packages job to solve error on publish.
Failed job reference: https://github.com/rango-exchange/rango-sdk/actions/runs/15375555713/job/43259880707