### PR TITLE
ci: remove since-start flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/detect-publish-flag
 
       - name: Publish packages
-        run: yarn run publish --since-start "$PUBLISH_FLAG"
+        run: yarn run publish "$PUBLISH_FLAG"
         env:
           PUBLISH_FLAG: ${{ steps.flag.outputs.flag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
we are removing it because we only needed it for the first publish to publish all packages from the start commit.
for subsequent publishes we shouldn't publish since the first commit