### PR TITLE
feat: add tokenUrl to ChainInfoBase

### DIFF
--- a/packages/rango-types/src/api/shared/meta.ts
+++ b/packages/rango-types/src/api/shared/meta.ts
@@ -23,6 +23,8 @@ export type MetaInfoType =
  * e.g. "https://bscscan.com/address/{wallet}"
  * @property {string} transactionUrl - Explorer transaction base url for this blockchain,
  * e.g. "https://bscscan.com/tx/{txHash}"
+ * @property {string | null} tokenUrl - Explorer token base url for this blockchain,
+ * e.g. "https://suiscan.xyz/mainnet/coin/{address}"
  *
  */
 export type ChainInfoBase = {
@@ -30,6 +32,7 @@ export type ChainInfoBase = {
   blockExplorerUrls: string[]
   addressUrl: string
   transactionUrl: string
+  tokenUrl: string | null
 }
 
 /**


### PR DESCRIPTION
Using the explorer with the token address works for some blockchains like BSC, but it does not work for others such as Sui. The server could provide an additional field for the token explorer URL so we can reliably open the correct token page across different blockchains.