### PR TITLE
docs: converted jsdocs to tsdocs

### DIFF
--- a/packages/rango-types/src/api/basic/common.ts
+++ b/packages/rango-types/src/api/basic/common.ts
@@ -19,104 +19,90 @@ export {
   RequestedAsset,
 }
 
-/**
- * EVM Fee Info for the Swap Fee
- *
- * @property {string} type - type of the fee meta
- * @property {string} gasLimit - gas limit
- * @property {string} gasPrice - gas price
- *
- */
+/** EVM Fee Info for the Swap Fee */
 export type EVMFeeMeta = {
+  /** type of the fee meta */
   type: 'EvmNetworkFeeMeta'
+  /** gas limit */
   gasLimit: string
+  /** gas price */
   gasPrice: string
 }
 
-/**
- * A fee unit, including the type of asset and the amount of fee
- *
- * @property {string} name - A display name for this fee, example: Network Fee
- * @property {Token} token - Underlying token for paying fee, example: BNB for BSC blockchain
- * @property {ExpenseType} expenseType - Type of the fee, example: FROM_SOURCE_WALLET
- * @property {string} amount - The human readable amount of fee, example: 0.004
- * @property {EVMFeeMeta | null} meta - Fee meta info for this type of blockchain. ATM, used for the EVM quotes.
- *
- */
+/** A fee unit, including the type of asset and the amount of fee */
 export type SwapFee = {
+  /** A display name for this fee, example: Network Fee */
   name: string
+  /** Underlying token for paying fee, example: BNB for BSC blockchain */
   token: Token
+  /** Type of the fee, example: FROM_SOURCE_WALLET */
   expenseType: ExpenseType
+  /** The human readable amount of fee, example: 0.004 */
   amount: string
+  /** Fee meta info for this type of blockchain. ATM, used for the EVM quotes. */
   meta: EVMFeeMeta | null
 }
 
-/**
- * A quote path from asset x (from) to asset y (to)
- *
- * @property {Token} from - The source asset
- * @property {Token} to - The destination asset
- * @property {SwapperMeta} swapper - Swapper for this path
- * @property {SwapperType} swapperType - Type of swapper
- * @property {string} inputAmount - Input amount
- * @property {string} expectedOutput - Expected output
- * @property {number} estimatedTimeInSeconds - Expected duration
- *
- */
+/** A quote path from asset x (from) to asset y (to) */
 export type QuotePath = {
+  /** The source asset */
   from: Token
+  /** The destination asset */
   to: Token
+  /** Swapper for this path */
   swapper: SwapperMeta
+  /** Type of swapper */
   swapperType: SwapperType
+  /** Input amount */
   inputAmount: string
+  /** Expected output */
   expectedOutput: string
+  /** Expected duration */
   estimatedTimeInSeconds: number
 }
 
-/**
- * Limitations on input amount for requested route
- *
- * @property {string | null} min - Limitation on minimum input amount for this route
- * @property {string | null} max - Limitation on maximum input amount for this route
- * @property {AmountRestrictionType} type - type of limitation
- *
- */
+/** Limitations on input amount for requested route */
 export type AmountRestriction = {
+  /** Limitation on minimum input amount for this route */
   min: string | null
+  /** Limitation on maximum input amount for this route */
   max: string | null
+  /** type of limitation */
   type: AmountRestrictionType
 }
 
-/**
- * A step of a multi-step swap route
- *
- * @property {Token} from - Source token
- * @property {Token} to - Destination token
- * @property {string} outputAmount - The estimation of Rango from output amount for Y
- * @property {string} outputAmountMin - The estimation of Rango from output amount for Y
- * @property {number | null} outputAmountUsd - The estimation of Rango from output usd value for Y
- * @property {SwapperMeta} swapper - Swapper suggested for this path
- * @property {QuotePath[] | null} path - The internal routing of this step showing how the initial swap request will
- * be split and executed. This can be used for previewing purpose to give the user a sense of what's going to happen.
- * Null indicates that there is no internal mechanism and swapping is simple and straight-forward.
- * @property {SwapFee[]} fee - List of fees that are taken from user in this step
- * @property {number | null} feeUsd - Amount of fee in usd
- * @property {AmountRestriction | null} amountRestriction - restrictions on input amount. This field is informational
- * and there is no need to apply it in client-side
- * @property {number} estimatedTimeInSeconds - The estimated time (in seconds) that this step might take, beware that
- * this number is just an estimation and should be used only for user preview, example: 15
- *
- */
+/** A step of a multi-step swap route */
 export type QuoteSimulationResult = {
+  /** Source token */
   from: Token
+  /** Destination token */
   to: Token
+  /** The estimation of Rango from output amount for Y */
   outputAmount: string
+  /** The estimation of Rango from output amount for Y */
   outputAmountMin: string
+  /** The estimation of Rango from output usd value for Y */
   outputAmountUsd: number | null
+  /** Swapper suggested for this path */
   swapper: SwapperMeta
+  /**
+   * The internal routing of this step showing how the initial swap request will
+   * be split and executed. This can be used for previewing purpose to give the user a sense of what's going to happen.
+   * Null indicates that there is no internal mechanism and swapping is simple and straight-forward.
+   */
   path: QuotePath[] | null
+  /** List of fees that are taken from user in this step */
   fee: SwapFee[]
+  /** Amount of fee in usd */
   feeUsd: number | null
+  /**
+   * restrictions on input amount. This field is informational
+   * and there is no need to apply it in client-side
+   */
   amountRestriction: AmountRestriction | null
+  /**
+   * The estimated time (in seconds) that this step might take, beware that
+   * this number is just an estimation and should be used only for user preview, example: 15
+   */
   estimatedTimeInSeconds: number
 }

--- a/packages/rango-types/src/api/basic/meta.ts
+++ b/packages/rango-types/src/api/basic/meta.ts
@@ -28,74 +28,62 @@ export {
   MessagingProtocolsResponse,
 }
 
-/**
- * All metadata info for a token, unique by (blockchain, symbol, address) tuple
- *
- * @property {string} blockchain - The blockchain which this token belongs to
- * @property {string | null} chainId - The chainId which this token belongs to, e.g. 1 for ETH, 56 for BSC and ...
- * @property {string | null} address - Smart contract address of token, null for native tokens
- * @property {string} symbol - The token symbol, e.g: ADA
- * @property {string | null} name - The token name, e.g: Binance Pegged ETH
- * @property {number} decimals - Decimals of token in blockchain, example: 18
- * @property {string} image - Url of its image, example: https://api.rango.exchange/tokens/ETH/ETH.png
- * @property {string} blockchainImage - Url of the blockchain image
- * @property {number | null} usdPrice - The token unit price
- * @property {boolean} isPopular - If true, means that the token is popular
- * @property {string[]} supportedSwappers - Supported Swappers for this token
- */
+/** All metadata info for a token, unique by (blockchain, symbol, address) tuple */
 export type Token = {
+  /** The blockchain which this token belongs to */
   blockchain: string
+  /** The chainId which this token belongs to, e.g. 1 for ETH, 56 for BSC and ... */
   chainId: string | null
+  /** Smart contract address of token, null for native tokens */
   address: string | null
+  /** The token symbol, e.g: ADA */
   symbol: string
+  /** The token name, e.g: Binance Pegged ETH */
   name: string | null
+  /** Decimals of token in blockchain, example: 18 */
   decimals: number
+  /** Url of its image, example: https://api.rango.exchange/tokens/ETH/ETH.png */
   image: string
+  /** Url of the blockchain image */
   blockchainImage: string
+  /** The token unit price */
   usdPrice: number | null
+  /** If true, means that the token is popular */
   isPopular: boolean
+  /** Supported Swappers for this token */
   supportedSwappers: string[]
 }
 
-/**
- * Metadata info for all blockchains and tokens supported
- *
- * @property {BlockchainMeta[]} blockchains - List of all supported blockchains
- * @property {Token[]} tokens - List of all tokens
- * @property {SwapperMeta[]} swappers - List of all DEXes & Bridges
- *
- */
+/** Metadata info for all blockchains and tokens supported */
 export type MetaResponse = {
+  /** List of all supported blockchains */
   blockchains: BlockchainMeta[]
+  /** List of all tokens */
   tokens: Token[]
+  /** List of all DEXes & Bridges */
   swappers: SwapperMeta[]
 }
 
-/**
- * Custom token request
- *
- * @property {string} blockchain - The blockchain that token belong to
- * @property {string} address - The contract address for the desired token
- *
- */
+/** Custom token request */
 export type CustomTokenRequest = {
+  /** The blockchain that token belong to */
   blockchain: string
+  /** The contract address for the desired token */
   address: string
 }
 
 /**
  * The custom token response which includes:
- * Token details for user desired token that is not available on Rango official list. 
+ * Token details for user desired token that is not available on Rango official list.
  * Currently supports Solana and EVM based blockchains.
- *
- * @property {Token} token - The destination asset
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
  */
 export type CustomTokenResponse = {
+  /** The destination asset */
   token: Token
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }

--- a/packages/rango-types/src/api/basic/routing.ts
+++ b/packages/rango-types/src/api/basic/routing.ts
@@ -3,101 +3,91 @@ import type { Asset, QuoteSimulationResult, RequestedAsset } from './common.js'
 
 export { RoutingResultType }
 
-/**
- * Body of quote request
- *
- * @property {RequestedAsset} from - The source asset
- * @property {RequestedAsset} to - The destination asset
- * @property {string} amount - The human-readable amount of asset X that is going to be swapped, example: 0.28
- * @property {number} [slippage] - User slippage, used to filter routes which are incompatible with this slippage
- * @property {string} [referrerCode] - Referrer code (or affiliate key) You could gnerate it using rango app affiliate menu
- * @property {number} [referrerFee] - Referrer fee in percent. e.g. 0.125 for 0.125% of input transaction fee per transaction
- * @property {string[]} [swappers] - List of all accepted swappers, an empty list means no filter is required
- * @property {boolean} [swappersExclude] - Indicates include/exclude mode for the swappers param
- * @property {string[]} [swapperGroups] - List of all accepted swapper groups, an empty list means no filter is required
- * @property {boolean} [swappersGroupsExclude] - Indicates include/exclude mode for the swappers group param
- * @property {string[]} [messagingProtocols] - List of all messaging protocols, an empty list means no filter is required
- * @property {string} [sourceContract] - Address of your contract on source chain (will be called in case of refund in the source chain)
- * @property {string} [destinationContract] - Address of your contract on destination chain (will be called in case of success/refund in the destination chain)
- * @property {string} [imMessage] - The message that you want to pass to your contract on the destination chain
- * @property {boolean} [contractCall] - Mark it true if you are going to call this quote via your own contract, so we
- * will filter routes that are not possible to be called from a contract
- * @property {boolean} [enableCentralizedSwappers] - You could set this parameter to true if you want to enable routing from the centralized protocols like Xo Swap.
- * By default, this parameter is false.
- * @property {boolean} [avoidNativeFee] - When it is true, Swappers that have native tokens as fee must be excluded. example: when you call it from AA account.
- *
- */
+/** Body of quote request */
 export type QuoteRequest = {
+  /** The source asset */
   from: RequestedAsset
+  /** The destination asset */
   to: RequestedAsset
+  /** The human-readable amount of asset X that is going to be swapped, example: 0.28 */
   amount: string
+  /** User slippage, used to filter routes which are incompatible with this slippage */
   slippage?: number
+  /** List of all accepted swappers, an empty list means no filter is required */
   swappers?: string[]
+  /** Indicates include/exclude mode for the swappers param */
   swappersExclude?: boolean
+  /** List of all accepted swapper groups, an empty list means no filter is required */
   swapperGroups?: string[]
+  /** Indicates include/exclude mode for the swappers group param */
   swappersGroupsExclude?: boolean
+  /** List of all messaging protocols, an empty list means no filter is required */
   messagingProtocols?: string[]
+  /** Address of your contract on source chain (will be called in case of refund in the source chain) */
   sourceContract?: string
+  /** Address of your contract on destination chain (will be called in case of success/refund in the destination chain) */
   destinationContract?: string
+  /** The message that you want to pass to your contract on the destination chain */
   imMessage?: string
+  /**
+   * Mark it true if you are going to call this quote via your own contract, so we
+   * will filter routes that are not possible to be called from a contract
+   */
   contractCall?: boolean
+  /**
+   * You could set this parameter to true if you want to enable routing from the centralized protocols like Xo Swap.
+   * By default, this parameter is false.
+   */
   enableCentralizedSwappers?: boolean
+  /** When it is true, Swappers that have native tokens as fee must be excluded. example: when you call it from AA account. */
   avoidNativeFee?: boolean
+  /** Referrer code (or affiliate key) You could gnerate it using rango app affiliate menu */
   referrerCode?: string
+  /** Referrer fee in percent. e.g. 0.125 for 0.125% of input transaction fee per transaction */
   referrerFee?: number
 }
 
-/**
- * The response of quote API, if the route field is null, it means that no route is found
- *
- * @property {string} requestId - The unique requestId which is generated for this request by the server. It should be
- * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
- * @property {RoutingResultType} resultType - Type of result for route (OK or error type)
- * @property {QuoteSimulationResult | null} route - Suggested route
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
- *
- */
+/** The response of quote API, if the route field is null, it means that no route is found */
 export type QuoteResponse = {
+  /**
+   * The unique requestId which is generated for this request by the server. It should be
+   * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
+   */
   requestId: string
+  /** Type of result for route (OK or error type) */
   resultType: RoutingResultType
+  /** Suggested route */
   route: QuoteSimulationResult | null
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }
 
-/**
- * The request body for connected assets API
- *
- * @property {RequestedAsset} from - the source asset which we are looking for the possible destination routes
- *
- */
+/** The request body for connected assets API */
 export type ConnectedAssetsRequest = {
+  /** the source asset which we are looking for the possible destination routes */
   from: RequestedAsset
 }
 
-/**
- * The type ConnectedAsset represents a blockchain with a list of assets
- *
- * @property {string} blockchain - The `blockchain` property in the `ConnectedAsset` type represents
- * the name of the blockchain to which the assets belong.
- * @property {Asset[]} assets - The `assets` property in the `ConnectedAsset` type is an array of
- * `Asset` objects. Each `Asset` object represents a specific asset within the blockchain
- *
- */
+/** The type ConnectedAsset represents a blockchain with a list of assets */
 export type ConnectedAsset = {
+  /**
+   * The `blockchain` property in the `ConnectedAsset` type represents
+   * the name of the blockchain to which the assets belong.
+   */
   blockchain: string
+  /**
+   * The `assets` property in the `ConnectedAsset` type is an array of
+   * `Asset` objects. Each `Asset` object represents a specific asset within the blockchain
+   */
   assets: Asset[]
 }
 
-/**
- * The response of connected assets API
- *
- * @property {ConnectedAsset[]} data - List of connected assets which they have probably routes from the source asset
- *
- */
+/** The response of connected assets API */
 export type ConnectedAssetsResponse = {
+  /** List of connected assets which they have probably routes from the source asset */
   data: ConnectedAsset[]
 }

--- a/packages/rango-types/src/api/basic/transactions.ts
+++ b/packages/rango-types/src/api/basic/transactions.ts
@@ -30,83 +30,75 @@ export {
   CheckApprovalResponse,
 }
 
-/**
- * Request body of check tx status
- *
- * @property {string} requestId - The unique ID which is generated in the best route endpoint
- * @property {number} txId - Tx hash that wallet returned, example: 0xa1a37ce2063c4764da27d990a22a0c89ed8ac585286a77a...
- *
- */
+/** Request body of check tx status */
 export type StatusRequest = {
+  /** The unique ID which is generated in the best route endpoint */
   requestId: string
+  /** Tx hash that wallet returned, example: 0xa1a37ce2063c4764da27d990a22a0c89ed8ac585286a77a... */
   txId: string
 }
 
-/**
- * Request body of swap endpoint
- *
- * @property {RequestedAsset} from - The source asset
- * @property {RequestedAsset} to - The destination asset
- * @property {string} amount - The human-readable amount of asset X that is going to be swapped, example: 0.28
- * @property {string} fromAddress - User source wallet address
- * @property {string} toAddress - User destination wallet address
- * @property {number} slippage - User slippage for this swap (e.g. 5.0 which means 5% slippage)
- * @property {boolean} [disableEstimate] - check pre-requests of a swap before creating tx (e.g. check having enough balance)
- * @property {string | null} [referrerCode] - Referrer code (or affiliate key) You could gnerate it using rango app affiliate menu
- * @property {string | null} [referrerAddress] - Referrer address
- * @property {string | null} [referrerFee] - Referrer fee in percent, (e.g. 0.3 means: 0.3% fee based on input amount)
- * @property {string[]} [swappers] - List of all accepted swappers, an empty list means no filter is required
- * @property {boolean} [swappersExclude] - Indicates include/exclude mode for the swappers param
- * @property {string[]} [swapperGroups] - List of all accepted swapper groups, an empty list means no filter is required
- * @property {boolean} [swappersGroupsExclude] - Indicates include/exclude mode for the swappers group param
- * @property {string[]} [messagingProtocols] - List of all messaging protocols, an empty list means no filter is required
- * @property {string} [sourceContract] - Address of your contract on source chain (will be called in case of refund in the source chain)
- * @property {string} [destinationContract] - Address of your contract on destination chain (will be called in case of success/refund in the destination chain)
- * @property {string} [imMessage] - The message that you want to pass to your contract on the destination chain
- * @property {boolean} [contractCall] - Mark it true if you are going to call this swap via your own contract, so we
- * will filter routes that are not possible to be called from a contract
- * @property {boolean} [enableCentralizedSwappers] - You could set this parameter to true if you want to enable routing from the centralized protocols like Xo Swap.
- * By default, this parameter is false.
- * @property {boolean} [infiniteApprove] - Infinite approval settings, default is false
- * @property {boolean} [avoidNativeFee] - When it is true, Swappers that have native tokens as fee must be excluded. example: when you call it from AA account.
- *
- */
+/** Request body of swap endpoint */
 export type SwapRequest = {
+  /** The source asset */
   from: RequestedAsset
+  /** The destination asset */
   to: RequestedAsset
+  /** The human-readable amount of asset X that is going to be swapped, example: 0.28 */
   amount: string
+  /** User source wallet address */
   fromAddress: string
+  /** User destination wallet address */
   toAddress: string
+  /** User slippage for this swap (e.g. 5.0 which means 5% slippage) */
   slippage: number
+  /** check pre-requests of a swap before creating tx (e.g. check having enough balance) */
   disableEstimate?: boolean
+  /** Referrer code (or affiliate key) You could gnerate it using rango app affiliate menu */
   referrerCode?: string
+  /** Referrer address */
   referrerAddress?: string | null
+  /** Referrer fee in percent, (e.g. 0.3 means: 0.3% fee based on input amount) */
   referrerFee?: string | null
+  /** List of all accepted swappers, an empty list means no filter is required */
   swappers?: string[]
+  /** Indicates include/exclude mode for the swappers param */
   swappersExclude?: boolean
+  /** List of all accepted swapper groups, an empty list means no filter is required */
   swapperGroups?: string[]
+  /** Indicates include/exclude mode for the swappers group param */
   swappersGroupsExclude?: boolean
+  /** List of all messaging protocols, an empty list means no filter is required */
   messagingProtocols?: string[]
+  /** Address of your contract on source chain (will be called in case of refund in the source chain) */
   sourceContract?: string
+  /** Address of your contract on destination chain (will be called in case of success/refund in the destination chain) */
   destinationContract?: string
+  /** The message that you want to pass to your contract on the destination chain */
   imMessage?: string
+  /**
+   * Mark it true if you are going to call this swap via your own contract, so we
+   * will filter routes that are not possible to be called from a contract
+   */
   contractCall?: boolean
+  /**
+   * You could set this parameter to true if you want to enable routing from the centralized protocols like Xo Swap.
+   * By default, this parameter is false.
+   */
   enableCentralizedSwappers?: boolean
+  /** Infinite approval settings, default is false */
   infiniteApprove?: boolean
+  /** When it is true, Swappers that have native tokens as fee must be excluded. example: when you call it from AA account. */
   avoidNativeFee?: boolean
 }
 
-/**
- * The final received asset and amount for a swap
- *
- * @property {string} amount - received token amount
- * @property {Token} receivedToken - received token asset
- * @property {string} type - type of received token
- *
- */
+/** The final received asset and amount for a swap */
 export type StatusOutput = {
+  /** received token amount */
   amount: string
+  /** received token asset */
   receivedToken: Token
+  /** type of received token */
   type:
     | 'REVERTED_TO_INPUT'
     | 'MIDDLE_ASSET_IN_SRC'
@@ -114,77 +106,73 @@ export type StatusOutput = {
     | 'DESIRED_OUTPUT'
 }
 
-/**
- * Tracking data for bridged token
- *
- * @property {number} srcChainId - source chain id
- * @property {string | null} srcTxHash - source transaction hash
- * @property {string | null} srcToken - source token address
- * @property {string} srcTokenAmt - source token amount
- * @property {number} srcTokenDecimals - source token decimals
- * @property {number | null} srcTokenPrice - source token price
- * @property {number} destChainId - destination chain id
- * @property {string | null} destTxHash - destination transaction hash
- * @property {string | null} destToken - destination token address
- * @property {string | null} destTokenAmt - destination token amount
- * @property {number} destTokenDecimals - destination token decimals
- * @property {number | null} destTokenPrice - destination token price
- *
- */
+/** Tracking data for bridged token */
 export type BridgeData = {
+  /** source chain id */
   srcChainId: number
+  /** source transaction hash */
   srcTxHash: string | null
+  /** source token address */
   srcToken: string | null
+  /** source token amount */
   srcTokenAmt: string
+  /** source token decimals */
   srcTokenDecimals: number
+  /** source token price */
   srcTokenPrice: string | null
+  /** destination chain id */
   destChainId: number
+  /** destination transaction hash */
   destTxHash: string | null
+  /** destination token address */
   destToken: string | null
+  /** destination token amount */
   destTokenAmt: string | null
+  /** destination token decimals */
   destTokenDecimals: number
+  /** destination token price */
   destTokenPrice: string | null
 }
 
-/**
- * Response of check transaction status containing the latest status of transaction in blockchain
- *
- * @property {TransactionStatus | null} status - Status of the transaction, while the status is running or null, the
- * client should retry until it turns into success or failed
- * @property {string | null} error - A message in case of failure, that could be shown to the user
- * @property {StatusOutput | null} output - The output asset and amount, it could be different from destination asset in
- * case of failures and refund
- * @property {SwapExplorerUrl[] | null} explorerUrl - List of explorer URLs for the transactions of this swap.
- * @property {string | null} diagnosisUrl - Some times transaction will fail and user need follow this diagnosis to redeem the assets.
- * @property {BridgeData | null} bridgeData - Status of bridge
- *
- */
+/** Response of check transaction status containing the latest status of transaction in blockchain */
 export type StatusResponse = {
+  /**
+   * Status of the transaction, while the status is running or null, the
+   * client should retry until it turns into success or failed
+   */
   status: TransactionStatus | null
+  /** A message in case of failure, that could be shown to the user */
   error: string | null
+  /**
+   * The output asset and amount, it could be different from destination asset in
+   * case of failures and refund
+   */
   output: StatusOutput | null
+  /** List of explorer URLs for the transactions of this swap. */
   explorerUrl: SwapExplorerUrl[] | null
+  /** Some times transaction will fail and user need follow this diagnosis to redeem the assets. */
   diagnosisUrl: string | null
+  /** Status of bridge */
   bridgeData: BridgeData | null
 }
 
 /**
  * Response body of swap API
  * @see https://docs.rango.exchange/integration/rango-sdk/sample-transactions
- *
- * @property {string} requestId - The unique requestId which is generated for this request by the server. It should be
- * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
- * @property {RoutingResultType} resultType - Type of result (OK or error type)
- * @property {QuoteSimulationResult | null} route - Suggested route
- * @property {string | null} error - Error message
- * @property {EvmTransaction | CosmosTransaction | SolanaTransaction | Transfer | StarknetTransaction | TronTransaction | null} transaction - Transaction data
- *
  */
 export type SwapResponse = {
+  /**
+   * The unique requestId which is generated for this request by the server. It should be
+   * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
+   */
   requestId: string
+  /** Type of result (OK or error type) */
   resultType: RoutingResultType
+  /** Suggested route */
   route: QuoteSimulationResult | null
+  /** Error message */
   error: string | null
+  /** Transaction data */
   tx:
     | EvmTransaction
     | CosmosTransaction

--- a/packages/rango-types/src/api/basic/txs/evm.ts
+++ b/packages/rango-types/src/api/basic/txs/evm.ts
@@ -3,42 +3,36 @@ import { TransactionType } from '../transactions.js'
 
 
 
-/**
- * Blockchain info for basic API EVM transaction
- */
+/** Blockchain info for basic API EVM transaction */
 export type EvmTransactionBlockchain = Pick<
   BlockchainMetaBase, 'name' | 'defaultDecimals' | 'addressPatterns' | 'feeAssets' | 'type' | 'chainId'
 >
 
-/**
- * The transaction object for all EVM-based blockchains, including Ethereum, BSC, Polygon, Harmony, etc
- *
- * @property {TransactionType} type - This fields equals to EVM for all EVMTransactions
- * @property {EvmTransactionBlockchain} blockChain - The blockchain info that this transaction is going to run in
- * @property {string | null} from - The source wallet address, it can be null
- * @property {string} approveTo - Address of source token erc20 contract for increasing approve amount
- * @property {string | null} approveData - The data of approve transaction
- * @property {string} txTo - Address of dex/bridge smart contract that is going to be called
- * @property {string | null} txData - The data of main transaction, it can be null in case of native token transfer
- * @property {string | null} value - The amount of transaction in case of native token transfer
- * @property {string | null} gasPrice - The suggested gas price for this transaction
- * @property {string | null} gasLimit - The suggested gas limit for this transaction
- * @property {string | null} maxPriorityFeePerGas - Suggested max priority fee per gas for this transaction
- * @property {string | null} maxFeePerGas - Suggested max fee per gas for this transaction
- *
- */
+/** The transaction object for all EVM-based blockchains, including Ethereum, BSC, Polygon, Harmony, etc */
 export interface EvmTransaction {
+  /** This fields equals to EVM for all EVMTransactions */
   type: TransactionType.EVM
+  /** The blockchain info that this transaction is going to run in */
   blockChain: EvmTransactionBlockchain
+  /** The source wallet address, it can be null */
   from: string | null
+  /** Address of source token erc20 contract for increasing approve amount */
   approveTo: string | null
+  /** The data of approve transaction */
   approveData: string | null
+  /** Address of dex/bridge smart contract that is going to be called */
   txTo: string
+  /** The data of main transaction, it can be null in case of native token transfer */
   txData: string | null
+  /** The amount of transaction in case of native token transfer */
   value: string | null
+  /** The suggested gas limit for this transaction */
   gasLimit: string | null
+  /** The suggested gas price for this transaction */
   gasPrice: string | null
+  /** Suggested max priority fee per gas for this transaction */
   maxPriorityFeePerGas: string | null
+  /** Suggested max fee per gas for this transaction */
   maxFeePerGas: string | null
 }
 

--- a/packages/rango-types/src/api/basic/txs/starknet.ts
+++ b/packages/rango-types/src/api/basic/txs/starknet.ts
@@ -4,19 +4,13 @@ import { TransactionType } from '../transactions.js'
 
 export { StarknetCallData }
 
-/**
- * The transaction object for all Starknet transactions
- *
- * @property {TransactionType} type - This fields equals to STARKNET for all StarknetTransaction
- * @property {string} blockChain - The blockchain name that this transaction is going to run in
- * @property {StarknetCallData[]} approveCalls - An array of StarknetCallData objects.
- * @property {StarknetCallData[]} calls - An array of StarknetCallData objects.
- * @property {number | null} maxFee
- *
- */
+/** The transaction object for all Starknet transactions */
 export interface StarknetTransaction extends BaseTransaction {
+  /** This fields equals to STARKNET for all StarknetTransaction */
   type: TransactionType.STARKNET
+  /** An array of StarknetCallData objects. */
   approveCalls: StarknetCallData[]
+  /** An array of StarknetCallData objects. */
   calls: StarknetCallData[]
   maxFee: number | null
 }

--- a/packages/rango-types/src/api/main/balance.ts
+++ b/packages/rango-types/src/api/main/balance.ts
@@ -7,30 +7,23 @@ import {
   Asset,
 } from '../shared/index.js'
 
-/**
- * The request for multiple token balances
- *
- * @property {Asset[]} assets - Tokens requesting their balances
- * @property {string} walletAddress - Wallet address
- *
- */
+/** The request for multiple token balances */
 export type MultipleTokenBalanceRequest = {
+  /** Tokens requesting their balances */
   assets: Asset[]
+  /** Wallet address */
   walletAddress: string
 }
 
-/**
- * the response for multiple token balances
- *
- * @property {AssetAndAmount[] | null} balances - The balances of tokens
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
- */
+/** the response for multiple token balances */
 export type MultipleTokenBalanceResponse = {
+  /** The balances of tokens */
   balances: AssetAndAmount[] | null
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }
 

--- a/packages/rango-types/src/api/main/common.ts
+++ b/packages/rango-types/src/api/main/common.ts
@@ -16,215 +16,168 @@ export {
   AssetWithTicker,
 }
 
-/**
- * Minimum required slippage of a step
- *
- * @property {boolean} error - If true, means that Rango failed to compute slippage for this step.
- * @property {string} slippage - The slippage amount in percent, example: 5
- *
- */
+/** Minimum required slippage of a step */
 export type RecommendedSlippage = {
+  /** If true, means that Rango failed to compute slippage for this step. */
   error: boolean
+  /** The slippage amount in percent, example: 5 */
   slippage: string
 }
 
-/**
- * EVM Fee Info for the Swap Fee
- *
- * @property {string} type - type of the fee meta 
- * @property {string} gasLimit - gas limit
- * @property {string} gasPrice - gas price
- *
- */
+/** EVM Fee Info for the Swap Fee */
 export type EVMFeeMeta = {
+  /** type of the fee meta  */
   type: "EvmNetworkFeeMeta",
+  /** gas limit */
   gasLimit: string,
+  /** gas price */
   gasPrice: string
 }
 
 
-/**
- * A fee unit, including the type of asset and the amount of fee
- *
- * @property {string} name - A display name for this fee, example: Network Fee
- * @property {Asset} asset - Underlying asset for paying fee, example: BNB for BSC blockchain
- * @property {string} amount - The human readable amount of fee, example: 0.004
- * @property {ExpenseType} expenseType - Type of the fee, example: FROM_SOURCE_WALLET
- * @property {number | null} price - Price of the fee asset
- *
- */
+/** A fee unit, including the type of asset and the amount of fee */
 export type SwapFee = {
+  /** A display name for this fee, example: Network Fee */
   name: string
+  /** Type of the fee, example: FROM_SOURCE_WALLET */
   expenseType: ExpenseType
+  /** Underlying asset for paying fee, example: BNB for BSC blockchain */
   asset: Asset
+  /** The human readable amount of fee, example: 0.004 */
   amount: string
+  /** Price of the fee asset */
   price: number | null
   meta: EVMFeeMeta | null
 }
 
-/**
- * Source or destination asset of a route step
- *
- * @property {string} blockchain - Blockchain of the source/destination asset of this step
- * @property {string} symbol - Symbol of the source/destination asset of this step, example: OSMO
- * @property {string | number} address - Contract address of the source/dest asset of this step, null for native token
- * @property {number} decimals - Decimals of the source/destination asset of this step, example: 18
- * @property {string} logo - Absolute path of the logo of the source/destination asset of this step
- * @property {string} blockchainLogo - Absolute path of the logo of the asset blockchain
- * @property {number | null} usdPrice - Usd price unit for the asset if available
- *
- */
+/** Source or destination asset of a route step */
 export type SwapResultAsset = {
+  /** Blockchain of the source/destination asset of this step */
   blockchain: string
+  /** Contract address of the source/dest asset of this step, null for native token */
   address: string | null
+  /** Symbol of the source/destination asset of this step, example: OSMO */
   symbol: string
+  /** Absolute path of the logo of the source/destination asset of this step */
   logo: string
+  /** Absolute path of the logo of the asset blockchain */
   blockchainLogo: string
+  /** Decimals of the source/destination asset of this step, example: 18 */
   decimals: number
+  /** Usd price unit for the asset if available */
   usdPrice: number | null
 }
 
-/**
- * A node of the swap path
- *
- * @property {string | null} marketId - Id of the market
- * @property {string | null} marketName - Name of the market, example: Uniswap
- * @property {number} percent - Percent of the allocation to this path, example: 45
- *
- */
+/** A node of the swap path */
 export type SwapNode = {
+  /** Id of the market */
   marketId: string | null
+  /** Name of the market, example: Uniswap */
   marketName: string
+  /** Percent of the allocation to this path, example: 45 */
   percent: number
 }
 
-/**
- * A swap path from asset x (from) to asset y (to)
- *
- * @property {string} from - Symbol of the source asset
- * @property {string | null} fromAddress - Contract address of source asset, null for native tokens
- * @property {string} fromBlockchain - Blockchain of the source asset
- * @property {string} fromLogo - Absolute path of logo of the source asset
- *
- * @property {string} to - Symbol of the destination asset
- * @property {string | null} toAddress - Contract address of destination asset, null for native tokens
- * @property {string} toBlockchain - Blockchain of the destination asset
- * @property {string} toLogo - Absolute path of logo of the destination asset
- *
- * @property {SwapNode[]} nodes - List of intermediate nodes in a swap path
- *
- */
+/** A swap path from asset x (from) to asset y (to) */
 export type SwapSuperNode = {
+  /** Symbol of the source asset */
   from: string
+  /** Contract address of source asset, null for native tokens */
   fromAddress: string | null
+  /** Blockchain of the source asset */
   fromBlockchain: string
+  /** Absolute path of logo of the source asset */
   fromLogo: string
+  /** Symbol of the destination asset */
   to: string
+  /** Contract address of destination asset, null for native tokens */
   toAddress: string | null
+  /** Blockchain of the destination asset */
   toBlockchain: string
+  /** Absolute path of logo of the destination asset */
   toLogo: string
+  /** List of intermediate nodes in a swap path */
   nodes: SwapNode[]
 }
 
-/**
- * Internal mechanism of a step
- *
- * @property {SwapSuperNode[] | null} nodes - List of parallel paths that splitting happens
- *
- */
+/** Internal mechanism of a step */
 export type SwapRoute = {
+  /** List of parallel paths that splitting happens */
   nodes: SwapSuperNode[] | null
 }
 
-/**
- * Time estimation details for a step of swap route
- *
- * @property {number} min - The minimum duration (in seconds) that usually takes for related step
- * @property {number} avg - The average duration (in seconds) that usually takes for related step
- * @property {number} max - The maximum duration (in seconds) that usually takes for related step
- *
- */
+/** Time estimation details for a step of swap route */
 export type TimeStat = {
+  /** The minimum duration (in seconds) that usually takes for related step */
   min: number
+  /** The average duration (in seconds) that usually takes for related step */
   avg: number
+  /** The maximum duration (in seconds) that usually takes for related step */
   max: number
 }
 
-/**
- * A step of a multi-step swap route
- *
- * @property {string} swapperId - Unique Id of swapper. example: PARASWAP
- *
- * @property {string} swapperLogo - Logo of the swapper
- *
- * @property {SwapperType} swapperType - Type of swapper. example: BRIDGE, DEX, AGGREGATOR
- *
- * @property {'INTER_CHAIN' | 'INTRA_CHAIN'} swapChainType - Type of swapping. It could be inter chain or intra chain
- *
- * @property {SwapResultAsset} from - The source asset
- *
- * @property {SwapResultAsset} to - The destination asset
- *
- * @property {string} fromAmount - Estimated input amount of this step. Can be used for previewing to user and should
- * not be used for real computation, since it may change when the real transaction happens due to volatility of the market
- *
- * @property {string} toAmount - Estimated output amount of this step. Can be used for previewing to user and should
- * not be used for real computation, since it may change when the real transaction happens due to volatility of the market
- *
- * @property {SwapRoute[] | null} routes - The internal routing of this step showing how the initial swap request will
- * be split and executed. This can be used for previewing purpose to give the user a sense of what's going to happen.
- * Null indicates that there is no internal mechanism and swapping is simple and straight-forward.
- *
- * @property {SwapResult[] | null} internalSwaps - The internal swaps for this step. Used for aggregators' internal steps.
- *
- * @property {SwapFee[]} fee - List of fees that are taken from user in this step
- *
- * @property {string | null} fromAmountMinValue - The minimum amount unit, the precision that will be applied to
- * transaction amount in create transaction endpoint automatically by Rango. This field is informational and there is
- * no need to apply it in client-side.
- *
- * @property {string | null} fromAmountMaxValue - Exactly the same as fromAmountMinValue, but for the maximum limit
- *
- * @property {string | null} fromAmountPrecision - The minimum amount unit, the precision that will be applied to
- * transaction amount in create transaction endpoint automatically by Rango. This field is informational and there
- * is no need to apply it in client-side
- *
- * @property {AmountRestrictionType} fromAmountRestrictionType - Type of from amount restriction
- *
- * @property {number} estimatedTimeInSeconds - The estimated time (in seconds) that this step might take, beware that
- * this number is just an estimation and should be used only for user preview, example: 15
- *
- * @property {TimeStat | null} timeStat - The minimum, avg and max estimation time for this step
- *
- * @property {boolean} includesDestinationTx - Is it required to sign a transaction on the destination chain or not
- *
- * @property {number} maxRequiredSign - Max number of transaction signing required by the user
- *
- * @property {RecommendedSlippage | null} recommendedSlippage
- *
- * @property {string[]} warnings - List of warnings for this swap step, it's usually an empty list
- *
- */
+/** A step of a multi-step swap route */
 export type SwapResult = {
+  /** Unique Id of swapper. example: PARASWAP */
   swapperId: string
+  /** Logo of the swapper */
   swapperLogo: string
+  /** Type of swapper. example: BRIDGE, DEX, AGGREGATOR */
   swapperType: SwapperType
+  /** Type of swapping. It could be inter chain or intra chain */
   swapChainType: 'INTER_CHAIN' | 'INTRA_CHAIN'
+  /** The source asset */
   from: SwapResultAsset
+  /** The destination asset */
   to: SwapResultAsset
+  /**
+   * Estimated output amount of this step. Can be used for previewing to user and should
+   * not be used for real computation, since it may change when the real transaction happens due to volatility of the market
+   */
   toAmount: string
+  /**
+   * Estimated input amount of this step. Can be used for previewing to user and should
+   * not be used for real computation, since it may change when the real transaction happens due to volatility of the market
+   */
   fromAmount: string
+  /** Exactly the same as fromAmountMinValue, but for the maximum limit */
   fromAmountMaxValue: string | null
+  /**
+   * The minimum amount unit, the precision that will be applied to
+   * transaction amount in create transaction endpoint automatically by Rango. This field is informational and there is
+   * no need to apply it in client-side.
+   */
   fromAmountMinValue: string | null
+  /**
+   * The minimum amount unit, the precision that will be applied to
+   * transaction amount in create transaction endpoint automatically by Rango. This field is informational and there
+   * is no need to apply it in client-side
+   */
   fromAmountPrecision: string | null
+  /** Type of from amount restriction */
   fromAmountRestrictionType: AmountRestrictionType
+  /**
+   * The internal routing of this step showing how the initial swap request will
+   * be split and executed. This can be used for previewing purpose to give the user a sense of what's going to happen.
+   * Null indicates that there is no internal mechanism and swapping is simple and straight-forward.
+   */
   routes: SwapRoute[] | null
+  /** The internal swaps for this step. Used for aggregators' internal steps. */
   internalSwaps: SwapResult[] | null
+  /** List of fees that are taken from user in this step */
   fee: SwapFee[]
+  /**
+   * The estimated time (in seconds) that this step might take, beware that
+   * this number is just an estimation and should be used only for user preview, example: 15
+   */
   estimatedTimeInSeconds: number
+  /** The minimum, avg and max estimation time for this step */
   timeStat: TimeStat | null
+  /** Is it required to sign a transaction on the destination chain or not */
   includesDestinationTx: boolean
+  /** Max number of transaction signing required by the user */
   maxRequiredSign: number
   recommendedSlippage: RecommendedSlippage | null
+  /** List of warnings for this swap step, it's usually an empty list */
   warnings: string[]
 }

--- a/packages/rango-types/src/api/main/meta.ts
+++ b/packages/rango-types/src/api/main/meta.ts
@@ -26,42 +26,35 @@ export {
   MessagingProtocolsResponse,
 }
 
-/**
- * All metadata info for a token, unique by (blockchain, symbol, address) tuple
- *
- * @property {string} blockchain - The blockchain which this token belongs to
- * @property {string | null} address - Smart contract address of token, null for native tokens
- * @property {string} symbol - The token symbol, e.g: ADA
- * @property {string | null} name - Display name of token, e.g: Cardano for ADA. It can be null
- * @property {number} decimals - Decimals of token in blockchain, example: 18
- * @property {string} image - Url of its image, example: https://api.rango.exchange/tokens/ETH/ETH.png
- * @property {number | null} usdPrice - USD unit price of this token if available
- * @property {boolean} isSecondaryCoin - If true, means that the token's trading is high risk. Better to warn user before proceeding
- * @property {string | null} coinSource - If the token is secondary, coinSource indicates the third-party list
- * that Rango found this token in, example: Pancake Extended List
- * @property {string | null} coinSourceUrl - The absolute url of the source list that token was extracted from
- * @property {boolean} isPopular - If true, means that the token is popular
- * @property {string[]} [supportedSwappers] - List of swappers that support this token
- *
- */
+/** All metadata info for a token, unique by (blockchain, symbol, address) tuple */
 export type Token = {
+  /** The blockchain which this token belongs to */
   blockchain: string
+  /** Smart contract address of token, null for native tokens */
   address: string | null
+  /** The token symbol, e.g: ADA */
   symbol: string
+  /** Display name of token, e.g: Cardano for ADA. It can be null */
   name: string | null
+  /** Decimals of token in blockchain, example: 18 */
   decimals: number
+  /** Url of its image, example: https://api.rango.exchange/tokens/ETH/ETH.png */
   image: string
+  /** USD unit price of this token if available */
   usdPrice: number | null
+  /** If true, means that the token's trading is high risk. Better to warn user before proceeding */
   isSecondaryCoin: boolean
+  /** If the token is secondary, coinSource indicates the third-party list that Rango found this token in, example: Pancake Extended List */
   coinSource: string | null
+  /** The absolute url of the source list that token was extracted from */
   coinSourceUrl: string | null
+  /** If true, means that the token is popular */
   isPopular: boolean
+  /** List of swappers that support this token */
   supportedSwappers?: string[]
 }
 
-/**
- * Compact version of token
- */
+/** Compact version of token */
 export type CompactToken = {
   b: string
   a: string | null
@@ -77,47 +70,35 @@ export type CompactToken = {
   ss?: string[]
 }
 
-/**
- * Metadata info for all blockchains and tokens supported
- *
- * @property {BlockchainMeta[]} blockchains - List of all supported blockchains
- * @property {Token[]} tokens - List of all tokens
- * @property {Token[]} popularTokens - List of popular tokens, a subset of tokens field
- * @property {SwapperMeta[]} swappers - List of all DEXes & Bridges
- *
- */
+/** Metadata info for all blockchains and tokens supported */
 export type MetaResponse = {
+  /** List of all supported blockchains */
   blockchains: BlockchainMeta[]
+  /** List of all tokens */
   tokens: Token[]
+  /** List of popular tokens, a subset of tokens field */
   popularTokens: Token[]
+  /** List of all DEXes & Bridges */
   swappers: SwapperMeta[]
 }
 
-/**
- * Compact Metadata info for all blockchains and tokens supported
- *
- * @property {BlockchainMeta[]} blockchains - List of all supported blockchains
- * @property {CompactToken[]} tokens - List of all tokens in compact format
- * @property {Token[]} popularTokens - List of popular tokens, a subset of tokens field
- * @property {SwapperMeta[]} swappers - List of all DEXes & Bridges
- *
- */
+/** Compact Metadata info for all blockchains and tokens supported */
 export type CompactMetaResponse = {
+  /** List of all supported blockchains */
   blockchains: BlockchainMeta[]
+  /** List of all tokens in compact format */
   tokens: CompactToken[]
+  /** List of popular tokens, a subset of tokens field */
   popularTokens: CompactToken[]
+  /** List of all DEXes & Bridges */
   swappers: SwapperMeta[]
 }
 
-/**
- * Custom token request
- *
- * @property {string} blockchain - The blockchain that token belong to
- * @property {string} address - The contract address for the desired token
- *
- */
+/** Custom token request */
 export type CustomTokenRequest = {
+  /** The blockchain that token belong to */
   blockchain: string
+  /** The contract address for the desired token */
   address: string
 }
 
@@ -125,38 +106,34 @@ export type CustomTokenRequest = {
  * The custom token response which includes:
  * Token details for user desired token that is not available on Rango official list.
  * Currently supports Solana and EVM based blockchains.
- *
- * @property {Token} token - The destination asset
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
  */
 export type CustomTokenResponse = {
+  /** The destination asset */
   token: Token
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }
 
-/**
- * The request to search for custom tokens
- *
- * @property {string} query - The search query string
- * @property {string} [blockchain] - An optional parameter to specify the blockchain for filtering results
- */
-export type SearchCustomTokensRequest = { query: string; blockchain?: string }
+/** The request to search for custom tokens */
+export type SearchCustomTokensRequest = {
+  /** The search query string */
+  query: string
+  /** An optional parameter to specify the blockchain for filtering results */
+  blockchain?: string
+}
 
-/**
- * The response for a custom token search
- *
- * @property {Token[]} tokens - List of tokens found in the searcH
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
- */
+/** The response for a custom token search */
 export type SearchCustomTokensResponse = {
+  /** List of tokens found in the searcH */
   tokens: Token[]
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }

--- a/packages/rango-types/src/api/main/routing.ts
+++ b/packages/rango-types/src/api/main/routing.ts
@@ -4,196 +4,180 @@ import type { TransactionType } from './transactions.js'
 
 export { RoutingResultType }
 
-/**
- * All user wallets for a specific blockchain
- *
- * @property {string} blockchain - The blockchain that wallets belong to
- * @property {string[]} addresses - List of user wallet addresses for the specified blockchain
- *
- */
+/** All user wallets for a specific blockchain */
 export type UserWalletBlockchain = {
+  /** The blockchain that wallets belong to */
   blockchain: string
+  /** List of user wallet addresses for the specified blockchain */
   addresses: string[]
 }
 
-/**
- * Full information of a path of multiple swaps that should be executed by user to swap X to Y
- *
- * @property {string} outputAmount - The estimation of Rango from output amount of Y
- * @property {RoutingResultType} resultType - Indicates that result is OK or have some problems such as Price Impact issue.
- * If there is a price impact issue Rango won't allow dApps to createTransaction and it will fail because of the risk of huge loss for user.
- * @property {SwapResult[]} swaps - List of required swaps to swap X to Y with the expected outputAmount
- *
- */
+/** Full information of a path of multiple swaps that should be executed by user to swap X to Y */
 export type SimulationResult = {
+  /** The estimation of Rango from output amount of Y */
   outputAmount: string
+  /**
+   * Indicates that result is OK or have some problems such as Price Impact issue.
+   * If there is a price impact issue Rango won't allow dApps to createTransaction and it will fail because of the risk of huge loss for user.
+   */
   resultType: RoutingResultType
+  /** List of required swaps to swap X to Y with the expected outputAmount */
   swaps: SwapResult[]
 }
 
-/**
- * Describing a required Asset for swapping X to Y and check if the wallet has enough balance or not
- *
- * @property {Asset} asset - asset required for fee or balance
- * @property {Asset} requiredAmount
- * @property {Amount} currentAmount
- * @property {boolean} ok - If true, means this requirement is fulfilled, false means swap may fail due to insufficient balance
- * @property {string} reason - 'FEE' | 'FEE_AND_INPUT_ASSET' | 'INPUT_ASSET'
- *
- */
+/** Describing a required Asset for swapping X to Y and check if the wallet has enough balance or not */
 export type WalletRequiredAssets = {
+  /** asset required for fee or balance */
   asset: Asset
   requiredAmount: Amount
   currentAmount: Amount
+  /** If true, means this requirement is fulfilled, false means swap may fail due to insufficient balance */
   ok: boolean
+  /** 'FEE' | 'FEE_AND_INPUT_ASSET' | 'INPUT_ASSET' */
   reason: 'FEE' | 'FEE_AND_INPUT_ASSET' | 'INPUT_ASSET'
 }
 
-/**
- * The validation status of a wallet
- *
- * @property {string} address - The address of wallet
- * @property {boolean} addressIsValid - If false, the wallet address is invalid for the given blockchain
- * @property {WalletRequiredAssets[]} requiredAssets - The list of required assets for swapping X to Y in this wallet
- * and the status to indicate whether these assets are missing or not
- * @property {boolean} validResult - If false, Rango was unable to fetch the balance of this address to check the
- * requiredAssets availability
- *
- */
+/** The validation status of a wallet */
 export type WalletValidationStatus = {
+  /** The address of wallet */
   address: string
+  /** If false, the wallet address is invalid for the given blockchain */
   addressIsValid: boolean
+  /**
+   * The list of required assets for swapping X to Y in this wallet
+   * and the status to indicate whether these assets are missing or not
+   */
   requiredAssets: WalletRequiredAssets[]
+  /** If false, Rango was unable to fetch the balance of this address to check the requiredAssets availability */
   validResult: boolean
 }
 
-/**
- * The blockchain that this validation data belongs to
- *
- * @property {string} blockchain - The blockchain of validation
- * @property {WalletValidationStatus[]} wallets - The status of validation for all the wallets of the specific blockchain
- *
- */
+/** The blockchain that this validation data belongs to */
 export type BlockchainValidationStatus = {
+  /** The blockchain of validation */
   blockchain: string
+  /** The status of validation for all the wallets of the specific blockchain */
   wallets: WalletValidationStatus[]
 }
 
-/**
- * The data required for relaying message from the source chain to the target chain in a cross-chain swap
- *
- * @property {string} sourceContract - Address of your contract on source chain (will be called in case of refund in the source chain)
- * @property {string} destinationContract - Address of your contract on destination chain (will be called in case of success/refund in the destination chain)
- * @property {string} imMessage - The message that you want to pass to your contract on the destination chain
- *
- */
+/** The data required for relaying message from the source chain to the target chain in a cross-chain swap */
 export type InterChainMessage = {
+  /** Address of your contract on source chain (will be called in case of refund in the source chain) */
   sourceContract: string
+  /** Address of your contract on destination chain (will be called in case of success/refund in the destination chain) */
   destinationContract: string
+  /** The message that you want to pass to your contract on the destination chain */
   imMessage: string
 }
 
-/**
- * Body of routing request
- *
- * @property {Asset} from - The source asset
- * @property {Asset} to - The destination asset
- * @property {string} amount - The human-readable amount of asset X that is going to be swapped, example: 0.28
- * @property {{ [key: string]: string }} selectedWallets - Map of blockchain to selected address
- * @property {UserWalletBlockchain[] | null} [connectedWallets] - List of all user connected wallet addresses per each blockchain
- * @property {boolean} [checkPrerequisites] - It should be false when client just likes to preview the route to user,
- * and true when user accepted to swap. If true, server will be slower to respond, but will check some pre-requisites including balance
- * of token X and required fees in user's wallets. The default value is false.
- * @property {string} [slippage] - User slippage, used to filter routes which are incompatible with this slippage
- * @property {string} [destination] - Custom destination for the route
- * @property {boolean} [forceExecution] - Use this flag if you want to ignore checkPrerequisites before executing the route
- * @property {string | null} [affiliateRef] - To enable dApps to charge affiliate fees and generate income from users' transactions,
- * the affiliate referral code should be provided. You can create this code by visiting the following link: https://app.rango.exchange/affiliate.
- * @property {number | null} [affiliatePercent] - If you want to change the default affiliate fee percentage, you can provide a new value here.
- * @property {{ [key: string]: string }} [affiliateWallets] - If you want to change the default affiliate wallet addresses, you can provide new values here.
- * (Map of route blockchains to affiliate address)
- * @property {boolean} [disableMultiStepTx] - It should be false when client wants to support multi-transactions per route step. default is true.
- * @property {string[]} [blockchains] - List of all accepted blockchains, an empty list means no filter is required
- * @property {string[]} [swappers] - List of all accepted swappers, an empty list means no filter is required
- * @property {boolean} [swappersExclude] - Indicates include/exclude mode for the swappers param
- * @property {string[]} [swapperGroups] - List of all accepted swapper groups, an empty list means no filter is required
- * @property {boolean} [swappersGroupsExclude] - Indicates include/exclude mode for the swappers group param
- * @property {TransactionType[]} [transactionTypes] - List of all accepted transaction types including [EVM, TRANSFER, COSMOS, ...]
- * @property {string[]} [messagingProtocols] - List of all messaging protocols, an empty list means no filter is required
- * @property {number} [maxLength] - Maximum number of steps in a route
- * @property {boolean} [experimental] - For enabling experimental features in routing
- * @property {boolean} [contractCall] - Mark it true if you are going to call this route via your own contract, so we
- * will filter routes that are not possible to be called from a contract
- * @property {InterChainMessage} [interChainMessage] - The data required for relaying message in a cross-chain swap
- * @property {boolean} [enableCentralizedSwappers] - You could set this parameter to true if you want to enable routing from the centralized protocols like Exodus.
- * By default, this parameter is false.
- * @property {boolean} [avoidNativeFee] - When it is true, Swappers that have native tokens as fee must be excluded. example: when you call it from AA account.
- *
- */
+/** Body of routing request */
 export type BestRouteRequest = {
+  /** The source asset */
   from: Asset
+  /** The destination asset */
   to: Asset
+  /** The human-readable amount of asset X that is going to be swapped, example: 0.28 */
   amount: string
+  /** Map of blockchain to selected address */
   selectedWallets: { [key: string]: string }
+  /** List of all user connected wallet addresses per each blockchain */
   connectedWallets?: UserWalletBlockchain[] | null
+  /**
+   * It should be false when client just likes to preview the route to user,
+   * and true when user accepted to swap. If true, server will be slower to respond, but will check some pre-requisites including balance
+   * of token X and required fees in user's wallets. The default value is false.
+   */
   checkPrerequisites?: boolean
+  /** User slippage, used to filter routes which are incompatible with this slippage */
   slippage?: string
+  /** Custom destination for the route */
   destination?: string
+  /** Use this flag if you want to ignore checkPrerequisites before executing the route */
   forceExecution?: boolean
+  /**
+   * To enable dApps to charge affiliate fees and generate income from users' transactions,
+   * the affiliate referral code should be provided. You can create this code by visiting the following link: https://app.rango.exchange/affiliate.
+   */
   affiliateRef?: string | null
+  /** If you want to change the default affiliate fee percentage, you can provide a new value here. */
   affiliatePercent?: number | null
+  /**
+   * If you want to change the default affiliate wallet addresses, you can provide new values here.
+   * (Map of route blockchains to affiliate address)
+   */
   affiliateWallets?: { [key: string]: string }
+  /** It should be false when client wants to support multi-transactions per route step. default is true. */
   disableMultiStepTx?: boolean
+  /** List of all accepted blockchains, an empty list means no filter is required */
   blockchains?: string[]
+  /** List of all accepted swappers, an empty list means no filter is required */
   swappers?: string[]
+  /** Indicates include/exclude mode for the swappers param */
   swappersExclude?: boolean
+  /** List of all accepted swapper groups, an empty list means no filter is required */
   swapperGroups?: string[]
+  /** Indicates include/exclude mode for the swappers group param */
   swappersGroupsExclude?: boolean
+  /** List of all accepted transaction types including [EVM, TRANSFER, COSMOS, ...] */
   transactionTypes?: TransactionType[]
+  /** List of all messaging protocols, an empty list means no filter is required */
   messagingProtocols?: string[]
+  /** Maximum number of steps in a route */
   maxLength?: number
+  /** For enabling experimental features in routing */
   experimental?: boolean
+  /**
+   * Mark it true if you are going to call this route via your own contract, so we
+   * will filter routes that are not possible to be called from a contract
+   */
   contractCall?: boolean
+  /** The data required for relaying message in a cross-chain swap */
   interChainMessage?: InterChainMessage | null
+  /**
+   * You could set this parameter to true if you want to enable routing from the centralized protocols like Exodus.
+   * By default, this parameter is false.
+   */
   enableCentralizedSwappers?: boolean
+  /** When it is true, Swappers that have native tokens as fee must be excluded. example: when you call it from AA account. */
   avoidNativeFee?: boolean
 }
 
-/**
- * The response of best route, if the result fields is null, it means that no route is found
- *
- * @property {string} requestId - The unique requestId which is generated for this request by the server. It should be
- * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
- * @property {string} requestAmount - The human readable input amount from the request
- * @property {Asset} from - The source asset
- * @property {Asset} to - The destination asset
- * @property {SimulationResult | null} result
- * @property {BlockchainValidationStatus[]} validationStatus - Pre-requisites check result. It will be null if
- * the request checkPrerequisites was false
- * @property {string[]} diagnosisMessages - list of string messages that might be cause of not finding the route.
- * It's just for display purposes
- * @property {string[]} missingBlockchains - List of all blockchains which are necessary to be present for the best
- * route and user has not provided any connected wallets for it. A null or empty list indicates that there is no problem.
- * @property {boolean} walletNotSupportingFromBlockchain - A warning indicates that none of your wallets have the same
- * blockchain as X asset
- * @property {boolean} boolean - A The state of confirm swap
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
- *
- */
+/** The response of best route, if the result fields is null, it means that no route is found */
 export type BestRouteResponse = {
+  /**
+   * The unique requestId which is generated for this request by the server. It should be
+   * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
+   */
   requestId: string
+  /** The human readable input amount from the request */
   requestAmount: string
+  /** The source asset */
   from: Asset
+  /** The destination asset */
   to: Asset
   result: SimulationResult | null
+  /**
+   * Pre-requisites check result. It will be null if
+   * the request checkPrerequisites was false
+   */
   validationStatus: BlockchainValidationStatus[]
+  /**
+   * list of string messages that might be cause of not finding the route.
+   * It's just for display purposes
+   */
   diagnosisMessages: string[]
+  /**
+   * List of all blockchains which are necessary to be present for the best
+   * route and user has not provided any connected wallets for it. A null or empty list indicates that there is no problem.
+   */
   missingBlockchains: string[]
+  /** A warning indicates that none of your wallets have the same blockchain as X asset */
   walletNotSupportingFromBlockchain: boolean
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }
 
@@ -205,120 +189,108 @@ export type Tag =
   | 'CENTRALIZED'
   | 'CAMPAIGN'
 
-/**
- * A tag that can be assigned to a route.
- */
+/** A tag that can be assigned to a route. */
 export type TagValue = Tag | Omit<string, Tag>
 
-/**
- * The multi-routing result tag.
- *
- * @property {string} label - The human-readable label.
- * @property {TagValue} value - The value of Tag.
- */
-export type RouteTag = { label: string; value: TagValue }
+/** The multi-routing result tag. */
+export type RouteTag = {
+  /** The human-readable label. */
+  label: string
+  /** The value of Tag. */
+  value: TagValue
+}
 
-/**
- * The type of preferences for sorting routes.
- */
+/** The type of preferences for sorting routes. */
 export type PreferenceType = 'FEE' | 'SPEED' | 'PRICE' | 'NET_OUTPUT' | 'SMART'
 
-/**
- * Score calculated for each preference for sorting in UI
- *
- * @property {PreferenceType} preferenceType - Type of evaluated aspect.
- * @property {number} score - Value of score (typically between 0 to 100).
- */
+/** Score calculated for each preference for sorting in UI */
 export type SimulationScore = {
+  /** Type of evaluated aspect. */
   preferenceType: PreferenceType
+  /** Value of score (typically between 0 to 100). */
   score: number
 }
 
-/**
- * Full information of a path of multiple swaps that should be executed by user to swap X to Y
- *
- * @property {string} requestId - The unique requestId which is generated for this request by the server. It should be
- * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
- * @property {string} outputAmount - The estimation of Rango from output amount of Y
- * @property {RoutingResultType} resultType - Indicates that result is OK or have some problems such as Price Impact issue.
- * If there is a price impact issue Rango won't allow dApps to createTransaction and it will fail because of the risk of huge loss for user.
- * @property {SwapResult[]} swaps - List of required swaps to swap X to Y with the expected outputAmount
- * @property {SimulationScore[]} scores - List of scores calculated for each preference aspect
- * @property {RouteTag[]} tags - List of tags attributed to each route considering every aspect
- * @property {string[]} missingBlockchains - List of all blockchains which are necessary to be present for the best
- * route and user has not provided any connected wallets for it. A null or empty list indicates that there is no problem.
- * @property {boolean} walletNotSupportingFromBlockchain - A warning indicates that none of your wallets have the same
- * blockchain as X asset
- */
+/** Full information of a path of multiple swaps that should be executed by user to swap X to Y */
 export type MultiRouteSimulationResult = {
+  /**
+   * The unique requestId which is generated for this request by the server. It should be
+   * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
+   */
   requestId: string
+  /** The estimation of Rango from output amount of Y */
   outputAmount: string
+  /**
+   * Indicates that result is OK or have some problems such as Price Impact issue.
+   * If there is a price impact issue Rango won't allow dApps to createTransaction and it will fail because of the risk of huge loss for user.
+   */
   resultType: RoutingResultType
+  /** List of required swaps to swap X to Y with the expected outputAmount */
   swaps: SwapResult[]
+  /** List of scores calculated for each preference aspect */
   scores: { preferenceType: PreferenceType; score: number }[]
+  /** List of tags attributed to each route considering every aspect */
   tags: RouteTag[]
-  missingBlockchains: string[] 
+  /**
+   * List of all blockchains which are necessary to be present for the best
+   * route and user has not provided any connected wallets for it. A null or empty list indicates that there is no problem.
+   */
+  missingBlockchains: string[]
+  /** A warning indicates that none of your wallets have the same blockchain as X asset */
   walletNotSupportingFromBlockchain: boolean
 }
 
-/**
- * The best route request body for multi-routing
- */
+/** The best route request body for multi-routing */
 export type MultiRouteRequest = Omit<BestRouteRequest, 'selectedWallets' | 'destination' | 'checkPrerequisites' | 'forceExecution' | 'maxLength'>
 
-/**
- * The best route response for multi-routing, if the results field is empty, it means that no route is found
- *
- * @property {Asset} from - The source asset
- * @property {Asset} to - The destination asset
- * @property {string} requestAmount - The human readable input amount from the request
- * @property {string} routeId - The unique roteId generated for this request by server
- * @property {MultiRouteSimulationResult} results - List of best routes data
- * @property {string[]} diagnosisMessages - list of string messages that might be cause of not finding the route.
- * It's just for display purposes
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
- */
+/** The best route response for multi-routing, if the results field is empty, it means that no route is found */
 export type MultiRouteResponse = {
+  /** The source asset */
   from: Asset
+  /** The destination asset */
   to: Asset
+  /** The human readable input amount from the request */
   requestAmount: string
+  /** The unique roteId generated for this request by server */
   routeId: string
+  /** List of best routes data */
   results: MultiRouteSimulationResult[]
+  /**
+   * list of string messages that might be cause of not finding the route.
+   * It's just for display purposes
+   */
   diagnosisMessages: string[]
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }
 
-/**
- * The body of confirmation request for selected route.
- *
- * @property {string} requestId - The unique requestId which is generated for this request by the server. It should be
- * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
- * @property {{ [key: string]: string }} selectedWallets - Map of blockchain to selected address
- * @property {string} [destination] - Custom destination for the route
- */
+/** The body of confirmation request for selected route. */
 export type ConfirmRouteRequest = {
+  /**
+   * The unique requestId which is generated for this request by the server. It should be
+   * passed down to all other endpoints if this swap continues on. e.g. d10657ce-b13a-405c-825b-b47f8a5016ad
+   */
   requestId: string
+  /** Map of blockchain to selected address */
   selectedWallets: { [key: string]: string }
+  /** Custom destination for the route */
   destination?: string
 }
 
-/**
- * The response of confirmation request for selected route
- *
- * @property {boolean} ok - If true, the result has a value and error message is null.
- * @property {BestRouteResponse | null} result - Result of confirm swap
- * @property {string | null} error - Error message about the incident if ok == false.
- * @property {string | null} errorCode - Error code about the incident if ok == false.
- * @property {number | null} traceId - Trace Id, for debug purpose
- */
+/** The response of confirmation request for selected route */
 export type ConfirmRouteResponse = {
+  /** If true, the result has a value and error message is null. */
   ok: boolean
+  /** Result of confirm swap */
   result: Omit<BestRouteResponse, 'error' | 'errorCode' | 'traceId'> | null
+  /** Error message about the incident if ok == false. */
   error: string | null
+  /** Error code about the incident if ok == false. */
   errorCode: string | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }

--- a/packages/rango-types/src/api/main/transactions.ts
+++ b/packages/rango-types/src/api/main/transactions.ts
@@ -38,99 +38,73 @@ export {
  * @deprecated use Transaction type instead
  * Parent model for all types of transactions
  * Check EvmTransaction, TransferTransaction and CosmosTransaction models for more details
- *
  */
 export type GenericTransaction = {
   type: TransactionType
 }
 
-/**
- * Data of referral rewards of a transaction
- *
- * @property {string} blockChain - The blockchain that reward is generated in, example: BSC
- * @property {string | null} address - The smart contract address of rewarded asset, null for native assets
- * @property {string} symbol - The symbol of the asset that is rewarded, example: ADA
- * @property {number} decimals - The decimals of the rewarded asset, example: 18
- * @property {string} amount - The machine-readable amount of the reward, example: 1000000000000000000
- *
- */
+/** Data of referral rewards of a transaction */
 export type TransactionStatusReferral = {
+  /** The blockchain that reward is generated in, example: BSC */
   blockChain: string
+  /** The smart contract address of rewarded asset, null for native assets */
   address: string | null
+  /** The symbol of the asset that is rewarded, example: ADA */
   symbol: string
+  /** The decimals of the rewarded asset, example: 18 */
   decimals: number
+  /** The machine-readable amount of the reward, example: 1000000000000000000 */
   amount: string
 }
 
-/**
- * Settings of user for swaps
- *
- * @property {string} slippage - Amount of users' preferred slippage in percent
- * @property {boolean} [infiniteApprove] - Infinite approval settings, default is false
- *
- */
+/** Settings of user for swaps */
 export type UserSettings = {
+  /** Amount of users' preferred slippage in percent */
   slippage: string
+  /** Infinite approval settings, default is false */
   infiniteApprove?: boolean
 }
 
-/**
- * List of validations that Rango should do
- *
- * @property {boolean} balance - If true [Recommended], Rango will check that user has the required balance for swap
- * @property {boolean} fee - If true [Recommended], Rango will check that user has the required fees in the wallet
- * @property {boolean} approve - If false, Rango will skip creating approve transactions for each step.
- *
- */
+/** List of validations that Rango should do */
 export type CreateTransactionValidation = {
+  /** If true [Recommended], Rango will check that user has the required balance for swap */
   balance: boolean
+  /** If true [Recommended], Rango will check that user has the required fees in the wallet */
   fee: boolean
+  /** If false, Rango will skip creating approve transactions for each step. */
   approve: boolean
 }
 
-/**
- * Request body of check tx status
- *
- * @property {string} requestId - The unique ID which is generated in the best route endpoint
- * @property {number} step - 1-based step number of a complex multi-step swap, example: 1, 2, ...
- * @property {number} txId - Tx hash that wallet returned, example: 0xa1a37ce2063c4764da27d990a22a0c89ed8ac585286a77a...
- *
- */
+/** Request body of check tx status */
 export type CheckTxStatusRequest = {
+  /** The unique ID which is generated in the best route endpoint */
   requestId: string
+  /** 1-based step number of a complex multi-step swap, example: 1, 2, ... */
   step: number
+  /** Tx hash that wallet returned, example: 0xa1a37ce2063c4764da27d990a22a0c89ed8ac585286a77a... */
   txId: string
 }
 
-/**
- * Request body of createTransaction endpoint
- *
- * @property {string} requestId - The unique ID which is generated in the best route endpoint
- * @property {number} step - 1-based step number of a complex multi-step swap, example: 1, 2, ...
- * @property {UserSettings} userSettings - user settings for the swap
- * @property {CreateTransactionValidation} validations - the validation checks we are interested to check by Rango
- * before starting the swap
- *
- */
+/** Request body of createTransaction endpoint */
 export type CreateTransactionRequest = {
+  /** The unique ID which is generated in the best route endpoint */
   requestId: string
+  /** 1-based step number of a complex multi-step swap, example: 1, 2, ... */
   step: number
+  /** user settings for the swap */
   userSettings: UserSettings
+  /** the validation checks we are interested to check by Rango before starting the swap */
   validations: CreateTransactionValidation
 }
 
-/**
- * The swapper details for a transaction step
- */
+/** The swapper details for a transaction step */
 export type SwapperStatusStep = {
   name: string
   state: 'PENDING' | 'CREATED' | 'WAITING' | 'SIGNED' | 'SUCCESSED' | 'FAILED'
   current: boolean
 }
 
-/**
- * Type of the transaction
- */
+/** Type of the transaction */
 export type Transaction =
   | EvmTransaction
   | CosmosTransaction
@@ -144,79 +118,80 @@ export type Transaction =
   | HyperliquidTransaction
   | Transfer
 
-/**
- * Extra data about executed transaction
- *
- * @property {boolean} requireRefundAction - Indicates whether the user must take any action to recover their assets from the underlying protocol.
- * While this situation is uncommon, there are rare cases where user assets may become stuck in the underlying protocol.
- * In such cases, manual intervention may be required to identify the user and process the refund.
- * @property {string | null} srcTx - Inbound transaction hash
- * @property {string | null} destTx - Outbound transaction hash in case of cross chain transaction
- *
- */
+/** Extra data about executed transaction */
 export type BridgeExtra = {
+  /**
+   * Indicates whether the user must take any action to recover their assets from the underlying protocol.
+   * While this situation is uncommon, there are rare cases where user assets may become stuck in the underlying protocol.
+   * In such cases, manual intervention may be required to identify the user and process the refund.
+   */
   requireRefundAction: boolean
+  /** Inbound transaction hash */
   srcTx: string | null
+  /** Outbound transaction hash in case of cross chain transaction */
   destTx: string | null
 }
 
-/**
- * Response of check transaction status containing the latest status of transaction
- *
- * @property {TransactionStatus | null} status - Status of the transaction, while the status is running or null, the
- * client should retry until it turns into success or failed
- * @property {number} timestamp - The timestamp of the executed transaction. Beware that timestamp can be null even if
- * the status is successful or failed, example: 1635271424813
- * @property {string | null} extraMessage - A message in case of failure, that could be shown to the user
- * @property {string | null} outputAmount - The output amount of the transaction if it was successful, exmaple: 0.28
- * @property {Token | null} outputToken - The output token, it could be the desired token or the refunded token
- * @property {string | null} outputType - Type of output token
- * @property {Transaction | null} newTx - if a transaction needs more than one-step transaction to be signed by
- * the user, the next step transaction will be returned in this field.
- * @property {string | null} diagnosisUrl - In some special cases [e.g. AnySwap], the user should follow some steps
- * outside Rango to get its assets back (refund). You can show this link to the user to help him
- * @property {SwapExplorerUrl[] | null} explorerUrl - List of explorer URLs for the transactions that happened in this step.
- * @property {TransactionStatusReferral[] | null} referrals - List of referral reward for the dApp and Rango
- * @property {SwapperStatusStep[] | null} steps - Internal steps details of a route step, used for solana
- * @property {BridgeExtra | null} bridgeExtra - Extra data about executed transaction
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
- */
+/** Response of check transaction status containing the latest status of transaction */
 export type TransactionStatusResponse = {
+  /**
+   * Status of the transaction, while the status is running or null, the
+   * client should retry until it turns into success or failed
+   */
   status: TransactionStatus | null
+  /**
+   * The timestamp of the executed transaction. Beware that timestamp can be null even if
+   * the status is successful or failed, example: 1635271424813
+   */
   timestamp: number | null
+  /** A message in case of failure, that could be shown to the user */
   extraMessage: string | null
+  /** The output amount of the transaction if it was successful, exmaple: 0.28 */
   outputAmount: string | null
+  /** The output token, it could be the desired token or the refunded token */
   outputToken: Token | null
+  /** Type of output token */
   outputType:
     | null
     | 'REVERTED_TO_INPUT'
     | 'MIDDLE_ASSET_IN_SRC'
     | 'MIDDLE_ASSET_IN_DEST'
     | 'DESIRED_OUTPUT'
+  /**
+   * if a transaction needs more than one-step transaction to be signed by
+   * the user, the next step transaction will be returned in this field.
+   */
   newTx: Transaction | null
+  /**
+   * In some special cases [e.g. AnySwap], the user should follow some steps
+   * outside Rango to get its assets back (refund). You can show this link to the user to help him
+   */
   diagnosisUrl: string | null
+  /** List of explorer URLs for the transactions that happened in this step. */
   explorerUrl: SwapExplorerUrl[] | null
+  /** List of referral reward for the dApp and Rango */
   referrals: TransactionStatusReferral[] | null
+  /** Internal steps details of a route step, used for solana */
   steps: SwapperStatusStep[] | null
+  /** Extra data about executed transaction */
   bridgeExtra: BridgeExtra | null
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }
 
 /**
  * Response body of create transaction, to see a list of example transactions
  * @see https://rango.exchange/apis/docs/tx-example
- *
- * @property {string | null} error - Error message about the incident if ok == false
- * @property {boolean} ok - If true, Rango has created a non-null transaction and the error message is null
- * @property {Transaction | null} transaction - Transaction data
- *
  */
 export type CreateTransactionResponse = {
+  /** Error message about the incident if ok == false */
   error: string | null
+  /** If true, Rango has created a non-null transaction and the error message is null */
   ok: boolean
+  /** Transaction data */
   transaction: Transaction | null
 }

--- a/packages/rango-types/src/api/main/txs/evm.ts
+++ b/packages/rango-types/src/api/main/txs/evm.ts
@@ -1,35 +1,32 @@
 import { BaseTransaction, TransactionType } from '../../shared/index.js'
 
-/**
- * The transaction object for all EVM-based blockchains, including Ethereum, BSC, Polygon, Harmony, etc
- *
- * @property {TransactionType} type - This fields equals to EVM for all EvmTransactions
- * @property {string} blockChain - The blockchain that this transaction is going to run in
- * @property {boolean} isApprovalTx - Determines that this transaction is an approval transaction or not, if true user
- * should approve the transaction and call create transaction endpoint again to get the original tx. Beware that most
- * of the fields of this object will be passed directly to the wallet without any change.
- * @property {string | null} from - The source wallet address, it can be null
- * @property {string} to - Address of destination wallet or the smart contract or token that is going to be called
- * @property {string | null} data - The data of smart contract call, it can be null in case of native token transfer
- * @property {string | null} value - The amount of transaction in case of native token transfer
- * @property {string | null} nonce - The nonce value for transaction
- * @property {string | null} gasPrice - The suggested gas price for this transaction
- * @property {string | null} gasLimit - The suggested gas limit for this transaction
- * @property {string | null} maxPriorityFeePerGas - Suggested max priority fee per gas for this transaction
- * @property {string | null} maxFeePerGas - Suggested max fee per gas for this transaction
- *
- */
+/** The transaction object for all EVM-based blockchains, including Ethereum, BSC, Polygon, Harmony, etc */
 export interface EvmTransaction extends BaseTransaction {
+  /** This fields equals to EVM for all EvmTransactions */
   type: TransactionType.EVM
+  /**
+   * Determines that this transaction is an approval transaction or not, if true user
+   * should approve the transaction and call create transaction endpoint again to get the original tx. Beware that most
+   * of the fields of this object will be passed directly to the wallet without any change.
+   */
   isApprovalTx: boolean
+  /** The source wallet address, it can be null */
   from: string | null
+  /** Address of destination wallet or the smart contract or token that is going to be called */
   to: string
+  /** The data of smart contract call, it can be null in case of native token transfer */
   data: string | null
+  /** The amount of transaction in case of native token transfer */
   value: string | null
+  /** The nonce value for transaction */
   nonce: string | null
+  /** The suggested gas limit for this transaction */
   gasLimit: string | null
+  /** The suggested gas price for this transaction */
   gasPrice: string | null
+  /** Suggested max priority fee per gas for this transaction */
   maxPriorityFeePerGas: string | null
+  /** Suggested max fee per gas for this transaction */
   maxFeePerGas: string | null
 }
 

--- a/packages/rango-types/src/api/main/txs/starknet.ts
+++ b/packages/rango-types/src/api/main/txs/starknet.ts
@@ -6,17 +6,13 @@ import {
 
 export { StarknetCallData }
 
-/**
- * StarknetTransaction
- *
- * @property {TransactionType} type - TransactionType.STARKNET
- * @property {boolean} isApprovalTx - If the transaction is an approval transaction, this will be true.
- * @property {StarknetCallData[]} calls - An array of StarknetCallData objects.
- *
- */
+/** StarknetTransaction */
 export interface StarknetTransaction extends BaseTransaction {
+  /** TransactionType.STARKNET */
   type: TransactionType.STARKNET
+  /** If the transaction is an approval transaction, this will be true. */
   isApprovalTx: boolean
+  /** An array of StarknetCallData objects. */
   calls: StarknetCallData[]
 }
 

--- a/packages/rango-types/src/api/shared/balance.ts
+++ b/packages/rango-types/src/api/shared/balance.ts
@@ -1,77 +1,57 @@
 import { Amount, Asset } from './common.js'
 
-/**
- * The asset, its amount in the wallet balance, and its price
- *
- * @property {Amount} amount
- * @property {Asset} asset
- * @property {number | null} price
- *
- */
+/** The asset, its amount in the wallet balance, and its price */
 export type AssetAndAmount = {
   amount: Amount
   asset: Asset
   price: number | null
 }
 
-/**
- * Balance of a specific address inside a specific blockchain
- *
- * @property {boolean} failed - If true, Rango was not able to fetch balance of this wallet, maybe try again later
- * @property {string} blockChain - Wallet blockchain
- * @property {string} address - Wallet address
- * @property {AssetAndAmount[] | null} balances - Examples: BSC, TERRA, OSMOSIS, ...
- * @property {string} explorerUrl - The explorer url of the wallet, example: https://bscscan.com/address/0x7a3....fdsza
- *
- */
+/** Balance of a specific address inside a specific blockchain */
 export type WalletDetail = {
+  /** If true, Rango was not able to fetch balance of this wallet, maybe try again later */
   failed: boolean
+  /** Wallet blockchain */
   blockChain: string
+  /** Wallet address */
   address: string
+  /** Examples: BSC, TERRA, OSMOSIS, ... */
   balances: AssetAndAmount[] | null
+  /** The explorer url of the wallet, example: https://bscscan.com/address/0x7a3....fdsza */
   explorerUrl: string
 }
 
-/**
- * Response of checking wallet balance
- *
- * @property {WalletDetail[]} wallets - list of wallet assets
- *
- */
+/** Response of checking wallet balance */
 export type WalletDetailsResponse = {
+  /** list of wallet assets */
   wallets: WalletDetail[]
 }
 
-/**
- * The token balance request
- *
- * @property {string} walletAddress - The user wallet address
- * @property {string} blockchain - The blockchain which this token belongs to
- * @property {string} symbol - The token symbol, e.g: ADA
- * This property is required only for COSMOS blockchains.
- * @property {string | null} address - Smart contract address of token, null for native tokens
- *
- */
+/** The token balance request */
 export type TokenBalanceRequest = {
+  /** The user wallet address */
   walletAddress: string
+  /** The blockchain which this token belongs to */
   blockchain: string
+  /**
+   * The token symbol, e.g: ADA
+   * This property is required only for COSMOS blockchains.
+   */
   symbol?: string
+  /** Smart contract address of token, null for native tokens */
   address: string | null
 }
 
-/**
- * The token balance response
- *
- * @property {number | null} balance - The balance for token
- * @property {number | null} price - The token's price.
- * @property {string | null} error - Error message
- * @property {number | null} errorCode - Error code
- * @property {number | null} traceId - Trace Id, for debug purpose
- */
+/** The token balance response */
 export type TokenBalanceResponse = {
+  /** The balance for token */
   balance: number | null
+  /** The token's price. */
   price: number | null
+  /** Error message */
   error: string | null
+  /** Error code */
   errorCode: number | null
+  /** Trace Id, for debug purpose */
   traceId: number | null
 }

--- a/packages/rango-types/src/api/shared/common.ts
+++ b/packages/rango-types/src/api/shared/common.ts
@@ -1,40 +1,28 @@
-/**
- * An asset which is unique by (blockchain, symbol, address)
- *
- * @property {string} blockchain - The blockchain which this token belongs to
- * @property {string | null} address - Smart contract address of token, null for native tokens
- * @property {string} symbol - The display token symbol, e.g. USDT, BTC, ...
- *
- */
+/** An asset which is unique by (blockchain, symbol, address) */
 export type Asset = {
+  /** The blockchain which this token belongs to */
   blockchain: string
+  /** Smart contract address of token, null for native tokens */
   address: string | null
+  /** The display token symbol, e.g. USDT, BTC, ... */
   symbol: string
 }
 
 /**
  * The amount of an asset, including value & decimals.
  * The value is machine-readable, to make it human-readable it should be shifted by decimals.
- *
- * @property {string} amount - The machine-readable amount shifted by decimals, example: 1000000000000000000
- * @property {number} decimals - The decimals of the token in blockchain, example: 18
- *
  */
 export type Amount = {
+  /** The machine-readable amount shifted by decimals, example: 1000000000000000000 */
   amount: string
+  /** The decimals of the token in blockchain, example: 18 */
   decimals: number
 }
 
-/**
- * Type of the swapper
- *
- */
+/** Type of the swapper */
 export type SwapperType = 'BRIDGE' | 'DEX' | 'AGGREGATOR' | 'OFF_CHAIN'
 
-/**
- * Type of the fee
- *
- */
+/** Type of the fee */
 export type ExpenseType =
   | 'FROM_SOURCE_WALLET'
   | 'DECREASE_FROM_OUTPUT'
@@ -44,38 +32,30 @@ export type ExpenseType =
  * Type of amount restriction: Specifies range for fromAmount (Min / Max) Value. for example if value
  * is EXCLUSIVE and fromAmountMinValue is 20, user can execute transaction if inputValue > 20, but for INCLUSIVE
  * inputValue >= 20 is valid
- *
  */
 export type AmountRestrictionType = 'INCLUSIVE' | 'EXCLUSIVE'
 
-/**
- * An asset with its ticker
- *
- * @property {string} blockchain - Blockchain of asset
- * @property {string | null} address - Contract address of the asset, null for native tokens
- * @property {string} symbol - Symbol of an asset, example: BUSD
- * @property {string} ticker - The ticker of the asset which normally is a combination of symbol and address,
- * required by some javascript wallets
- *
- */
+/** An asset with its ticker */
 export type AssetWithTicker = {
+  /** Blockchain of asset */
   blockchain: string
+  /** Contract address of the asset, null for native tokens */
   address: string | null
+  /** Symbol of an asset, example: BUSD */
   symbol: string
+  /** The ticker of the asset which normally is a combination of symbol and address, required by some javascript wallets */
   ticker: string
 }
 
-/**
- * An asset which is unique by (blockchain, symbol, address)
- *
- * @property {string} blockchain - The blockchain which this token belongs to
- * @property {string | null} address - Smart contract address of token, null for native tokens
- * @property {string} [symbol]  symbol - The display token symbol, e.g. USDT, BTC, ...
- * This property is required only for COSMOS blockchains.
- *
- */
+/** An asset which is unique by (blockchain, symbol, address) */
 export type RequestedAsset = {
+  /** The blockchain which this token belongs to */
   blockchain: string
+  /** Smart contract address of token, null for native tokens */
   address: string | null
+  /**
+   * The display token symbol, e.g. USDT, BTC, ...
+   * This property is required only for COSMOS blockchains.
+   */
   symbol?: string
 }

--- a/packages/rango-types/src/api/shared/meta.ts
+++ b/packages/rango-types/src/api/shared/meta.ts
@@ -16,58 +16,42 @@ export type MetaInfoType =
 /**
  * ChainInfoBase
  * Base type for all chains info type
- *
- * @property {MetaInfoType} infoType - Type of chain info
- * @property {string[]} blockExplorerUrls - e.g. "https://polygonscan.com"
- * @property {string} addressUrl - Explorer address base url for this blockchain,
- * e.g. "https://bscscan.com/address/{wallet}"
- * @property {string} transactionUrl - Explorer transaction base url for this blockchain,
- * e.g. "https://bscscan.com/tx/{txHash}"
- * @property {string | null} tokenUrl - Explorer token base url for this blockchain,
- * e.g. "https://suiscan.xyz/mainnet/coin/{address}"
- *
  */
 export type ChainInfoBase = {
+  /** Type of chain info */
   infoType: MetaInfoType
+  /** e.g. "https://polygonscan.com" */
   blockExplorerUrls: string[]
+  /** Explorer address base url for this blockchain, e.g. "https://bscscan.com/address/{wallet}" */
   addressUrl: string
+  /** Explorer transaction base url for this blockchain, e.g. "https://bscscan.com/tx/{txHash}" */
   transactionUrl: string
+  /** Explorer token base url for this blockchain, e.g. "https://suiscan.xyz/mainnet/coin/{address}" */
   tokenUrl: string | null
 }
 
-/**
- * EVM Chain Info
- *
- * @property {MetaInfoType} infoType - equals to EvmMetaInfo for EvmChainInfo
- * @property {string} chainName - Chain name, e.g. Polygon Mainnet
- * @property {name: string, symbol: string, decimals: number} nativeCurrency
- * @property {string[]} rpcUrls - e.g. "https://polygon-rpc.com"
- * @property {boolean} enableGasV2 - It's true for some chains like Ethereum which we support
- * new model of gas price (i.e. maxFeePerGas and maxPriorityFeePerGas) for them
- *
- */
+/** EVM Chain Info */
 export interface EVMChainInfo extends ChainInfoBase {
+  /** equals to EvmMetaInfo for EvmChainInfo */
   infoType: 'EvmMetaInfo'
+  /** Chain name, e.g. Polygon Mainnet */
   chainName: string
   nativeCurrency: {
     name: string
     symbol: string
     decimals: number
   }
+  /** e.g. "https://polygon-rpc.com" */
   rpcUrls: string[]
+  /** It's true for some chains like Ethereum which we support new model of gas price (i.e. maxFeePerGas and maxPriorityFeePerGas) for them */
   enableGasV2: boolean
 }
 
-/**
- * StarkNet Chain Info
- *
- * @property {MetaInfoType} infoType - equals to StarkNetMetaInfo for StarkNet
- * @property {string} chainName - Chain name
- * @property {name: string, symbol: string, decimals: number} nativeCurrency
- *
- */
+/** StarkNet Chain Info */
 export interface StarkNetChainInfo extends ChainInfoBase {
+  /** equals to StarkNetMetaInfo for StarkNet */
   infoType: 'StarkNetMetaInfo'
+  /** Chain name */
   chainName: string
   nativeCurrency: {
     name: string
@@ -76,69 +60,42 @@ export interface StarkNetChainInfo extends ChainInfoBase {
   }
 }
 
-/**
- * Tron Chain Info
- *
- */
+/** Tron Chain Info */
 export type TronChainInfo = EVMChainInfo
 
-/**
- * Solana Chain Info
- *
- * @property {MetaInfoType} infoType - equals to SolanaMetaInfo for Solana
- *
- */
+/** Solana Chain Info */
 export interface SolanaChainInfo extends ChainInfoBase {
+  /** equals to SolanaMetaInfo for Solana */
   infoType: 'SolanaMetaInfo'
 }
 
-/**
- * Transfer Chain Info
- *
- * @property {MetaInfoType} infoType - equals to TransferMetaInfo for blockhains that uses UTXO
- *
- */
+/** Transfer Chain Info */
 export interface TransferChainInfo extends ChainInfoBase {
+  /** equals to TransferMetaInfo for blockhains that uses UTXO */
   infoType: 'TransferMetaInfo'
 }
 
-/**
- * Sui Chain Info
- *
- * @property {MetaInfoType} infoType - equals to SuiMetaInfo for Sui
- *
- */
+/** Sui Chain Info */
 export interface SuiChainInfo extends ChainInfoBase {
+  /** equals to SuiMetaInfo for Sui */
   infoType: 'SuiMetaInfo'
 }
 
-/**
- * Xrpl Chain Info
- *
- * @property {MetaInfoType} infoType - equals to XrplMetaInfo for XRPL
- *
- */
+/** Xrpl Chain Info */
 export interface XrplChainInfo extends ChainInfoBase {
+  /** equals to XrplMetaInfo for XRPL */
   infoType: 'XRPLMetaInfo'
 }
 
-/**
- * Hyperliquid Chain Info
- *
- * @property {MetaInfoType} infoType - equals to HyperliquidMetaInfo for Hyperliquid
- *
- */
+/** Hyperliquid Chain Info */
 export interface HyperliquidChainInfo extends ChainInfoBase {
+  /** equals to HyperliquidMetaInfo for Hyperliquid */
   infoType: 'HyperliquidMetaInfo'
 }
 
-/**
- * Stellar Chain Info
- *
- * @property {MetaInfoType} infoType - equals to SteallarMetaInfo for STELLAR
- *
- */
+/** Stellar Chain Info */
 export interface StellarChainInfo extends ChainInfoBase {
+  /** equals to SteallarMetaInfo for STELLAR */
   infoType: 'StellarMetaInfo'
 }
 
@@ -146,7 +103,6 @@ export interface StellarChainInfo extends ChainInfoBase {
  * Cosmos Chain Info - Used for adding experimental chains to keplr if needed
  *
  * @see https://github.com/osmosis-labs/osmosis-frontend/blob/0b88e39740cb087be576f464bfcd6cc2971ed2fd/packages/web/config/chain-infos.ts
- *
  */
 export interface CosmosChainInfo extends ChainInfoBase {
   infoType: 'CosmosMetaInfo'
@@ -199,58 +155,43 @@ export interface CosmosChainInfo extends ChainInfoBase {
   } | null
 }
 
-/**
- * Metadata of Swapper
- *
- * @property {string} id - Unique identifier for the swapper
- * @property {string} title - Display name for the swapper
- * @property {string} logo - Icon logo for the swapper
- * @property {string} swapperGroup - Group name for swapper
- * @property {SwapperType[]} types - Type of the transaction supported by the swapper
- * @property {boolean} enabled - It indicates whether swapper is currently enabled or not
- *
- */
+/** Metadata of Swapper */
 export type SwapperMeta = {
+  /** Unique identifier for the swapper */
   id: string
+  /** Display name for the swapper */
   title: string
+  /** Icon logo for the swapper */
   logo: string
+  /** Group name for swapper */
   swapperGroup: string
+  /** Type of the transaction supported by the swapper */
   types: SwapperType[]
+  /** It indicates whether swapper is currently enabled or not */
   enabled: boolean
 }
 
-/**
- * Supported blockchains for a swapper
- *
- * @property {string} source - Name of the source blockchain
- * @property {string} destinations - List of all possible target blockchains for this source blockchain
- *
- */
+/** Supported blockchains for a swapper */
 export type SupportedBlockchains = {
+  /** Name of the source blockchain */
   source: string
+  /** List of all possible target blockchains for this source blockchain */
   destinations: string[]
 }
 
-/**
- * Metadata of Swapper plus additional info e.g. supported blockchains
- *
- * @property {SupportedBlockchains[]} supportedBlockchains - supported blockchains for the swapper
- *
- */
+/** Metadata of Swapper plus additional info e.g. supported blockchains */
 export type SwapperMetaExtended = SwapperMeta & {
+  /** supported blockchains for the swapper */
   supportedBlockchains: SupportedBlockchains[]
 }
 
 /**
  * Metadata of Swapper
  * @deprecated use SwapperMeta istead
- *
  */
 export type SwapperMetaDto = SwapperMeta
 
-/**
- * Chain specific information
- */
+/** Chain specific information */
 export type ChainInfo =
   | EVMChainInfo
   | CosmosChainInfo
@@ -263,38 +204,33 @@ export type ChainInfo =
   | StellarChainInfo
   | HyperliquidChainInfo
 
-/**
- * Blockchain Meta Information
- *
- * @property {TransactionType} type - Type of the blockchain
- * @property {string} name - Unique name of blockchain, this field is used in all endpoints as the identifier
- * @property {number} defaultDecimals - The default decimals of blockchain, do not use it in computations, use Token.decimals instead
- * @property {Asset[]} feeAssets - List of assets that can be used as fee in this blockchain
- * @property {string[]} addressPatterns - List of all regex patterns for wallet addresses of this blockchain, can be
- * used for input validation, example: [ "^(0x)[0-9A-Fa-f]{40}$" ]
- * @property {string} logo - Logo of the blockchain
- * @property {string} displayName - Display name for the blockchain
- * @property {string} shortName - Short name for the blockchain
- * @property {string} color - Suggested color for the blockchain
- * @property {number} sort - Suggested sort for the blockchain
- * @property {boolean} enabled - Is blockchain enabled or not in Rango
- * @property {string | null} chainId - e.g. "0xa86a" for Avax, "osmosis-1" for Osmosis, etc.
- * @property {ChainInfo | null} info - Chain specific information
- *
- */
+/** Blockchain Meta Information */
 export type BlockchainMetaBase = {
+  /** Type of the blockchain */
   type: TransactionType
+  /** Unique name of blockchain, this field is used in all endpoints as the identifier */
   name: string
+  /** Short name for the blockchain */
   shortName: string
+  /** Display name for the blockchain */
   displayName: string
+  /** The default decimals of blockchain, do not use it in computations, use Token.decimals instead */
   defaultDecimals: number
+  /** List of assets that can be used as fee in this blockchain */
   feeAssets: Asset[]
+  /** List of all regex patterns for wallet addresses of this blockchain, can be used for input validation, example: [ "^(0x)[0-9A-Fa-f]{40}$" ] */
   addressPatterns: string[]
+  /** Logo of the blockchain */
   logo: string
+  /** Suggested color for the blockchain */
   color: string
+  /** Suggested sort for the blockchain */
   sort: number
+  /** Is blockchain enabled or not in Rango */
   enabled: boolean
+  /** e.g. "0xa86a" for Avax, "osmosis-1" for Osmosis, etc. */
   chainId: string | null
+  /** Chain specific information */
   info: ChainInfo | null
 }
 
@@ -377,73 +313,71 @@ export type BlockchainMeta =
   | StellarBlockchainMeta
   | HyperliquidBlockchainMeta
 
-/**
- * MessagingProtocol
- *
- * @property {string} id - The unique identifier for the messaging protocol.
- *
- */
+/** MessagingProtocol */
 export type MessagingProtocol = {
+  /** The unique identifier for the messaging protocol. */
   id: string
 }
 
-/**
- * Metadata info for all supported messaging protcols
- *
- * @property {MessagingProtocol[]} protocols - List of all supported messaging protocols, e.g. AXELAR, ...
- *
- */
+/** Metadata info for all supported messaging protcols */
 export type MessagingProtocolsResponse = {
+  /** List of all supported messaging protocols, e.g. AXELAR, ... */
   protocols: MessagingProtocol[]
 }
 
-/**
- * The MetaRequest type is used to specify the filter parameters for the meta endpoint.
- *
- * @property {string[]} [blockchains] - An array of strings representing the blockchains to include in
- * the request.
- * @property {boolean} [blockchainsExclude] - A boolean value indicating whether the specified
- * blockchains should be excluded or included in the response. If set to true, the specified blockchains
- * will be excluded. If set to false or not provided, the specified blockchains will be included.
- * @property {string[]} [swappers] - An array of strings representing the Id of swappers.
- * @property {boolean} [swappersExclude] - The `swappersExclude` property is a boolean value that
- * indicates whether to exclude or include specific swappers in the response. If set to `true`, it means
- * that the swappers specified in the `swappers` property should be excluded from the response. If set
- * to `false` or not
- * @property {string[]} [swappersGroups] - The `swappersGroups` property is an array of strings that
- * represents the groups of swappers. This property allows you to
- * specify which swapper groups you want to include or exclude
- * @property {boolean} [swappersGroupsExclude] - The `swappersGroupsExclude` property is a boolean value
- * that determines whether to exclude or include swapper groups. If set to `true`, it means that the
- * specified swapper groups should be excluded from the response. If set to `false` or not provided, the
- * specified swapper groups should
- * @property {TransactionType[]} [transactionTypes] - The `transactionTypes` property is an array of
- * `TransactionType` values. It specifies the types of transactions that should be included in the meta
- * response.
- * @property {boolean} [transactionTypesExclude] - The `transactionTypesExclude` property is a boolean
- * value that indicates whether the specified transaction types should be excluded or included in the
- * response. If set to `true`, the specified transaction types will be excluded from the response. If set
- * to `false` or not provided, the specified transaction types will be
- * @property {boolean} [excludeSecondaries] - The `excludeSecondaries` property is a boolean flag that
- * indicates whether secondary tokens should be excluded from the response.
- * @property {boolean} [excludeNonPopulars] - The `excludeNonPopulars` property is a boolean value that
- * indicates whether non-popular token should be excluded from the response.
- * @property {boolean} [ignoreSupportedSwappers] - A boolean value indicating whether to include supported
- * swappers list per token in response.
- * @property {boolean} [enableCentralizedSwappers] - You could set this parameter to true if you want to enable routing from the centralized protocols like Exodus.
- * By default, this parameter is false.
- */
+/** The MetaRequest type is used to specify the filter parameters for the meta endpoint. */
 export type MetaRequest = {
+  /** An array of strings representing the blockchains to include in the request. */
   blockchains?: string[]
+  /**
+   * A boolean value indicating whether the specified blockchains should be excluded or included in the response. If set to true, the specified blockchains
+   * will be excluded. If set to false or not provided, the specified blockchains will be included.
+   */
   blockchainsExclude?: boolean
+  /** An array of strings representing the Id of swappers. */
   swappers?: string[]
+  /**
+   * The `swappersExclude` property is a boolean value that
+   * indicates whether to exclude or include specific swappers in the response. If set to `true`, it means
+   * that the swappers specified in the `swappers` property should be excluded from the response. If set
+   * to `false` or not
+   */
   swappersExclude?: boolean
+  /**
+   * The `swappersGroups` property is an array of strings that
+   * represents the groups of swappers. This property allows you to
+   * specify which swapper groups you want to include or exclude
+   */
   swappersGroups?: string[]
+  /**
+   * The `swappersGroupsExclude` property is a boolean value
+   * that determines whether to exclude or include swapper groups. If set to `true`, it means that the
+   * specified swapper groups should be excluded from the response. If set to `false` or not provided, the
+   * specified swapper groups should
+   */
   swappersGroupsExclude?: boolean
+  /**
+   * The `transactionTypes` property is an array of
+   * `TransactionType` values. It specifies the types of transactions that should be included in the meta
+   * response.
+   */
   transactionTypes?: TransactionType[]
+  /**
+   * The `transactionTypesExclude` property is a boolean
+   * value that indicates whether the specified transaction types should be excluded or included in the
+   * response. If set to `true`, the specified transaction types will be excluded from the response. If set
+   * to `false` or not provided, the specified transaction types will be
+   */
   transactionTypesExclude?: boolean
+  /** The `excludeSecondaries` property is a boolean flag that indicates whether secondary tokens should be excluded from the response. */
   excludeSecondaries?: boolean
+  /** The `excludeNonPopulars` property is a boolean value that indicates whether non-popular token should be excluded from the response. */
   excludeNonPopulars?: boolean
+  /** A boolean value indicating whether to include supported swappers list per token in response. */
   ignoreSupportedSwappers?: boolean
+  /**
+   * You could set this parameter to true if you want to enable routing from the centralized protocols like Exodus.
+   * By default, this parameter is false.
+   */
   enableCentralizedSwappers?: boolean
 }

--- a/packages/rango-types/src/api/shared/transactions.ts
+++ b/packages/rango-types/src/api/shared/transactions.ts
@@ -1,6 +1,4 @@
-/**
- * The type of transaction
- */
+/** The type of transaction */
 export enum TransactionType {
   EVM = 'EVM',
   TRANSFER = 'TRANSFER',
@@ -26,16 +24,11 @@ export enum GenericTransactionType {
   SOLANA = 'SOLANA',
 }
 
-/**
- * A transaction's url that can be displayed to advanced user to track the progress
- *
- * @property {string} url - Url of the transaction in blockchain explorer. example: https://etherscan.io/tx/0xa1a3...
- * @property {string | null} description - A custom display name to help user distinguish the transactions from each
- * other. Example: Inbound, Outbound, Bridge, or null
- *
- */
+/** A transaction's url that can be displayed to advanced user to track the progress */
 export type SwapExplorerUrl = {
+  /** A custom display name to help user distinguish the transactions from each other. Example: Inbound, Outbound, Bridge, or null */
   description: string | null
+  /** Url of the transaction in blockchain explorer. example: https://etherscan.io/tx/0xa1a3... */
   url: string
 }
 
@@ -43,7 +36,6 @@ export type SwapExplorerUrl = {
  * APIErrorCode
  *
  * Error code of a swap failure
- *
  */
 export type APIErrorCode =
   | 'TX_FAIL'
@@ -87,27 +79,23 @@ export function isAPIErrorCode(value: string): value is APIErrorCode {
  *
  * It should be used when an error happened in client and we want to inform server that transaction failed,
  * E.g. user rejected the transaction dialog or and an RPC error raised during signing tx by user.
- *
- * @property {string} requestId - The requestId from best route endpoint
- * @property {APIErrorCode} eventType - Type of the event that happened, example: USER_REJECT
- * @property {number} [step] - Step number in which failure happened
- * @property {string} [reason] - Reason or message for the error
- * @property {[key: string]: string} [data] - @deprecated A list of key-value for extra details
- * @property {wallet?: string, errorCode? string} [tags] - A list of key-value for pre-defined tags
- *
  */
 export type ReportTransactionRequest = {
+  /** The requestId from best route endpoint */
   requestId: string
+  /** Type of the event that happened, example: USER_REJECT */
   eventType: APIErrorCode
+  /** Step number in which failure happened */
   step?: number
+  /** Reason or message for the error */
   reason?: string
+  /** @deprecated A list of key-value for extra details */
   data?: { [key: string]: string }
+  /** A list of key-value for pre-defined tags */
   tags?: { wallet?: string; errorCode?: string }
 }
 
-/**
- * The status of transaction in tracking
- */
+/** The status of transaction in tracking */
 export enum TransactionStatus {
   FAILED = 'failed',
   RUNNING = 'running',
@@ -124,17 +112,17 @@ export enum TransactionStatus {
  *  3- approval transaction succeeded but currentApprovedAmount is still less than requiredApprovedAmount
  *  (e.g. user changed transaction data and enter another approve amount in MetaMask)
  *  => isApproved = false && txStatus == 'success'
- *
- * @property {boolean} isApproved - A flag which indicates that the approve tx is done or not
- * @property {TransactionStatus | null} txStatus - Status of approve transaction in blockchain,
- * if isArppoved is false and txStatus is failed, it seems that approve transaction failed in blockchain
- * @property {string | null} requiredApprovedAmount - required amount to be approved by user
- * @property {string | null} currentApprovedAmount - current approved amount by user
- *
  */
 export type CheckApprovalResponse = {
+  /** A flag which indicates that the approve tx is done or not */
   isApproved: boolean
+  /**
+   * Status of approve transaction in blockchain,
+   * if isArppoved is false and txStatus is failed, it seems that approve transaction failed in blockchain
+   */
   txStatus: TransactionStatus | null
+  /** required amount to be approved by user */
   requiredApprovedAmount: string | null
+  /** current approved amount by user */
   currentApprovedAmount: string | null
 }

--- a/packages/rango-types/src/api/shared/txs/base.ts
+++ b/packages/rango-types/src/api/shared/txs/base.ts
@@ -1,15 +1,11 @@
 import { TransactionType } from '../transactions.js'
 import { TransactionPrerequisite } from '../prerequisites/index.js'
 
-/**
- * Base transaction for all Rango supported transactions
- *
- * @property {TransactionType} type - Type of the transaction, e.g. EVM, SOLANA, COSMOS, ...
- * @property {string} blockChain - The blockchain that this transaction will be executed in
- *
- */
+/** Base transaction for all Rango supported transactions */
 export interface BaseTransaction {
+  /** Type of the transaction, e.g. EVM, SOLANA, COSMOS, ... */
   type: TransactionType
+  /** The blockchain that this transaction will be executed in */
   blockChain: string
   prerequisites: TransactionPrerequisite[]
 }

--- a/packages/rango-types/src/api/shared/txs/cosmos.ts
+++ b/packages/rango-types/src/api/shared/txs/cosmos.ts
@@ -2,33 +2,25 @@ import { AssetWithTicker } from '../common.js'
 import { TransactionType } from '../transactions.js'
 import { BaseTransaction } from './base.js'
 
-/**
- * CosmosCoin
- */
+/** CosmosCoin */
 export type CosmosCoin = {
   amount: string
   denom: string
 }
 
-/**
- * CosmosProtoMsg
- */
+/** CosmosProtoMsg */
 export type CosmosProtoMsg = {
   type_url: string
   value: number[]
 }
 
-/**
- * CosmosFee representing fee for cosmos transaction
- */
+/** CosmosFee representing fee for cosmos transaction */
 export type CosmosFee = {
   gas: string
   amount: CosmosCoin[]
 }
 
-/**
- * Main transaction object for COSMOS type transactions
- */
+/** Main transaction object for COSMOS type transactions */
 export type CosmosMessage = {
   signType: 'AMINO' | 'DIRECT'
   sequence: string | null
@@ -41,40 +33,32 @@ export type CosmosMessage = {
   memo: string | null
   fee: CosmosFee | null
 }
-/**
- * An alternative to CosmosMessage object for the cosmos wallets that do not support generic Cosmos messages (e.g. XDefi)
- *
- * @property {AssetWithTicker} asset - The asset to be transferred
- * @property {string} amount - The machine-readable amount to transfer, example: 1000000000000000000
- * @property {number} decimals - The decimals for this asset, example: 18
- * @property {string | null} memo - Memo of transaction, could be null
- * @property {string} method - The transaction method, example: transfer, deposit
- * @property {string} recipient - The recipient address of transaction
- *
- */
+
+/** An alternative to CosmosMessage object for the cosmos wallets that do not support generic Cosmos messages (e.g. XDefi) */
 export type CosmosRawTransferData = {
+  /** The machine-readable amount to transfer, example: 1000000000000000000 */
   amount: string
+  /** The asset to be transferred */
   asset: AssetWithTicker
+  /** The decimals for this asset, example: 18 */
   decimals: number
+  /** Memo of transaction, could be null */
   memo: string | null
+  /** The transaction method, example: transfer, deposit */
   method: string
+  /** The recipient address of transaction */
   recipient: string
 }
 
-/**
- * A Cosmos transaction, child of GenericTransaction
- *
- * @property {TransactionType} type - This fields equals to COSMOS for all CosmosTransactions
- * @property {string} blockChain - The blockchain that this transaction will be executed in, same as the input blockchain of creating transaction
- * @property {string} fromWalletAddress - Address of wallet that this transaction should be executed in, same as the create transaction request's input
- * @property {CosmosMessage} data - Transaction data
- * @property {CosmosRawTransferData | null} rawTransfer - An alternative to CosmosMessage object for the cosmos wallets that do not support generic Cosmos messages
- *
- */
+/** A Cosmos transaction, child of GenericTransaction */
 export interface CosmosTransaction extends BaseTransaction {
+  /** This fields equals to COSMOS for all CosmosTransactions */
   type: TransactionType.COSMOS
+  /** Address of wallet that this transaction should be executed in, same as the create transaction request's input */
   fromWalletAddress: string
+  /** Transaction data */
   data: CosmosMessage
+  /** An alternative to CosmosMessage object for the cosmos wallets that do not support generic Cosmos messages */
   rawTransfer: CosmosRawTransferData | null
 }
 

--- a/packages/rango-types/src/api/shared/txs/hyperliquid.ts
+++ b/packages/rango-types/src/api/shared/txs/hyperliquid.ts
@@ -10,23 +10,19 @@ interface HyperliquidAction {
   time: number
 }
 
-/**
- * This type of transaction is used for all Hyperliquid transactions
- *
- * @property {TransactionType} type - This fields equals to HYPERLIQUID for all HyperliquidTransactions
- * @property {HyperliquidAction} action - Hyperliquid transaction action
- * @property {string} message, message to be signed by wallet
- * @property {string} nonce, nonce of transaction
- * @property {string} prerequisites, This field is an empty array for Hyperliquid transactions
- * @property {string | null} expectedOutput, expected output of transaction
- *
- */
+/** This type of transaction is used for all Hyperliquid transactions */
 export interface HyperliquidTransaction extends BaseTransaction {
+  /** This fields equals to HYPERLIQUID for all HyperliquidTransactions */
   type: TransactionType.HYPERLIQUID
+  /** Hyperliquid transaction action */
   action: HyperliquidAction
+  /** message to be signed by wallet */
   message: string
+  /** nonce of transaction */
   nonce: number
+  /** This field is an empty array for Hyperliquid transactions */
   prerequisites: []
+  /** expected output of transaction */
   expectedOutput: string
 }
 

--- a/packages/rango-types/src/api/shared/txs/solana.ts
+++ b/packages/rango-types/src/api/shared/txs/solana.ts
@@ -1,54 +1,43 @@
 import { TransactionType } from '../transactions.js'
 import { BaseTransaction } from './base.js'
 
-/**
- * Account metadata used to define instructions
- */
+/** Account metadata used to define instructions */
 export type SolanaInstructionKey = {
   pubkey: string
   isSigner: boolean
   isWritable: boolean
 }
 
-/**
- * Transaction Instruction class
- */
+/** Transaction Instruction class */
 export type SolanaInstruction = {
   keys: SolanaInstructionKey[]
   programId: string
   data: number[]
 }
 
-/**
- * Pair of signature and corresponding public key
- */
+/** Pair of signature and corresponding public key */
 export type SolanaSignature = {
   signature: number[]
   publicKey: string
 }
 
-/**
- * This type of transaction is used for all solana transactions
- *
- * @property {TransactionType} type - This fields equals to SOLANA for all SolanaTransactions
- * @property {'LEGACY' | 'VERSIONED'} txType - Type of the solana transaction
- * @property {string} blockChain, equals to SOLANA
- * @property {string} from, Source wallet address
- * @property {string} identifier, Transaction hash used in case of retry
- * @property {string | null} recentBlockhash, A recent blockhash
- * @property {SolanaSignature[]} signatures, Signatures for the transaction
- * @property {number[] | null} serializedMessage, The byte array of the transaction
- * @property {SolanaInstruction[]} instructions, The instructions to atomically execute
- *
- */
+/** This type of transaction is used for all solana transactions */
 export interface SolanaTransaction extends BaseTransaction {
+  /** This fields equals to SOLANA for all SolanaTransactions */
   type: TransactionType.SOLANA
+  /** Type of the solana transaction */
   txType: 'LEGACY' | 'VERSIONED'
+  /** Source wallet address */
   from: string
+  /** Transaction hash used in case of retry */
   identifier: string
+  /** A recent blockhash */
   recentBlockhash: string | null
+  /** Signatures for the transaction */
   signatures: SolanaSignature[]
+  /** The byte array of the transaction */
   serializedMessage: number[] | null
+  /** The instructions to atomically execute */
   instructions: SolanaInstruction[]
 }
 

--- a/packages/rango-types/src/api/shared/txs/ton.ts
+++ b/packages/rango-types/src/api/shared/txs/ton.ts
@@ -6,33 +6,31 @@ export enum TonChainID {
   TESTNET = '-3',
 }
 
-/**
- * @property {string} address - Receiver's address
- * @property {string} amount - Amount to send in nanoTon
- * @property {string} [stateInit] - Contract specific data to add to the transaction
- * @property {string} [payload] - Contract specific data to add to the transaction
- */
+/** Ton transaction message */
 export interface TonMessage {
+  /** Receiver's address */
   address: string
+  /** Amount to send in nanoTon */
   amount: string
+  /** Contract specific data to add to the transaction */
   stateInit?: string
+  /** Contract specific data to add to the transaction */
   payload?: string
 }
 
-/**
- * This type of transaction is used for all Ton transactions
- *
- * @property {TransactionType} type - This field equals to TON for all Ton transactions
- * @property {number} validUntil - Sending transaction deadline in unix epoch seconds
- * @property {TonChainID} [network] - The network (mainnet or testnet) where DApp intends to send the transaction. If not set, the transaction is sent to the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the network parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SEND this transaction
- * @property {string} [from] - The sender address in '<wc>:<hex>' format from which DApp intends to send the transaction. Current account.address by default
- * @property {TonMessage[]} messages - Messages to send: min is 1, max is 4
- */
+/** This type of transaction is used for all Ton transactions */
 export interface TonTransaction extends BaseTransaction {
+  /** This field equals to TON for all Ton transactions */
   type: TransactionType.TON
+  /** Sending transaction deadline in unix epoch seconds */
   validUntil: number
+  /**
+   * The network (mainnet or testnet) where DApp intends to send the transaction. If not set, the transaction is sent to the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the network parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SEND this transaction
+   */
   network?: TonChainID
+  /** The sender address in '<wc>:<hex>' format from which DApp intends to send the transaction. Current account.address by default */
   from?: string
+  /** Messages to send: min is 1, max is 4 */
   messages: TonMessage[]
 }
 

--- a/packages/rango-types/src/api/shared/txs/transfer.ts
+++ b/packages/rango-types/src/api/shared/txs/transfer.ts
@@ -3,38 +3,32 @@ import { TransactionType } from '../transactions.js'
 import { BaseTransaction } from './base.js'
 
 export type InputToSign = { address: string, signingIndexes: number[] }
-/**
- * @property {unsignedPsbtBase64} unsignedPsbtBase64 - Base 64 representation of the Unsigned PSBT
- * @property {InputToSign[]} inputsToSign - Inputs to be signed
- */
+
 export type PSBT = {
+  /** Base 64 representation of the Unsigned PSBT */
   unsignedPsbtBase64: string
+  /** Inputs to be signed */
   inputsToSign: InputToSign[]
 }
-/**
- * TransferTransaction. This type of transaction is used for UTXO blockchains including BTC, LTC, BCH
- *
- * @property {TransactionType} type - This fields equals to TRANSFER for all TransferTransactions
- * @property {string} blockChain - The blockchain that this transaction will be executed in, same as the input blockchain of creating transaction
- * @property {string} method - The method that should be passed to wallet. examples: deposit, transfer
- * @property {AssetWithTicker} asset
- * @property {string} amount - The machine-readable amount of transaction, example: 1000000000000000000
- * @property {number} decimals - The decimals of the asset
- * @property {string} fromWalletAddress - The source wallet address that can sign this transaction
- * @property {string} recipientAddress - The destination wallet address that the fund should be sent to
- * @property {string | null} memo - The memo of transaction, can be null
- * @property {PSBT | null} psbt - PSBT object containing base 64 representation of the Unsigned PSBT along with the inputs to be signed
- *
- */
+
+/** TransferTransaction. This type of transaction is used for UTXO blockchains including BTC, LTC, BCH */
 export interface Transfer extends BaseTransaction {
+  /** This fields equals to TRANSFER for all TransferTransactions */
   type: TransactionType.TRANSFER
+  /** The method that should be passed to wallet. examples: deposit, transfer */
   method: string
   asset: AssetWithTicker
+  /** The machine-readable amount of transaction, example: 1000000000000000000 */
   amount: string
+  /** The decimals of the asset */
   decimals: number
+  /** The source wallet address that can sign this transaction */
   fromWalletAddress: string
+  /** The destination wallet address that the fund should be sent to */
   recipientAddress: string
+  /** The memo of transaction, can be null */
   memo: string | null
+  /** PSBT object containing base 64 representation of the Unsigned PSBT along with the inputs to be signed */
   psbt: PSBT | null
 }
 

--- a/packages/rango-types/src/api/shared/txs/tron.ts
+++ b/packages/rango-types/src/api/shared/txs/tron.ts
@@ -19,23 +19,19 @@ export type TrxRawData = {
   timestamp: number
 }
 
-/**
- * TronTransaction
- *
- * @property {TransactionType} type - TransactionType.TRON
- * @property {boolean} isApprovalTx - Whether or not the transaction is an approval transaction.
- * @property {TrxRawData | null} raw_data - This is the raw data of the transaction.
- * @property {string | null} raw_data_hex - The raw hex data of the transaction.
- * @property {string} txID - The transaction ID.
- * @property {boolean} visible - boolean
- * @property {object} __payload__
- */
+/** TronTransaction */
 export interface TronTransaction extends BaseTransaction {
+  /** TransactionType.TRON */
   type: TransactionType.TRON
+  /** Whether or not the transaction is an approval transaction. */
   isApprovalTx: boolean
+  /** This is the raw data of the transaction. */
   raw_data: TrxRawData | null
+  /** The raw hex data of the transaction. */
   raw_data_hex: string | null
+  /** The transaction ID. */
   txID: string
+  /** boolean */
   visible: boolean
   __payload__: object
 }


### PR DESCRIPTION
## Migrate rango-types JSDoc comments to TypeDoc-compatible format

Migrates all JSDoc comments in `rango-types` from block/object-level annotations to property-level format, enabling TypeDoc to correctly parse and generate API documentation for the library's exported types.

### Changes

- Moved all doc comments to property-level (`/** ... */` directly above each property) across all types, interfaces, and enums in `rango-types`

### Testing

Verified by running `npx typedoc src/index.ts` in the `rango-types` repo and spot-checking the generated output for a representative sample of key types to confirm descriptions are correctly surfaced.

> **Note:** Before running `npx typedoc src/index.ts`, add `"ignoreDeprecations": "6.0"` to `tsconfig.json` to suppress the `moduleResolution=node10` deprecation error thrown by TypeScript.