### PR TITLE
feat(types): add EVM_APPROVE and TRON_APPROVE prerequisite types

### DIFF
--- a/packages/rango-types/src/api/shared/prerequisites/base.ts
+++ b/packages/rango-types/src/api/shared/prerequisites/base.ts
@@ -1,9 +1,13 @@
+import { EvmApprovePrerequisite } from './evm.js'
 import { StellarChangeTrustLinePrerequisite } from './stellar.js'
+import { TronApprovePrerequisite } from './tron.js'
 import { XrplChangeTrustLinePrerequisite } from './xrpl.js'
 
 export type TransactionPrerequisiteType =
   | StellarChangeTrustLinePrerequisite['type']
   | XrplChangeTrustLinePrerequisite['type']
+  | EvmApprovePrerequisite['type']
+  | TronApprovePrerequisite['type']
 export interface BaseTransactionPrerequisite {
   type: TransactionPrerequisiteType
   blockChain: string

--- a/packages/rango-types/src/api/shared/prerequisites/constants.ts
+++ b/packages/rango-types/src/api/shared/prerequisites/constants.ts
@@ -1,2 +1,4 @@
 export const XRPL_CHANGE_TRUSTLINE_TYPE = 'XRPL_CHANGE_TRUSTLINE' as const
 export const STELLAR_CHANGE_TRUSTLINE_TYPE = 'STELLAR_CHANGE_TRUSTLINE' as const
+export const EVM_APPROVE_TYPE = 'EVM_APPROVE' as const
+export const TRON_APPROVE_TYPE = 'TRON_APPROVE' as const

--- a/packages/rango-types/src/api/shared/prerequisites/evm.ts
+++ b/packages/rango-types/src/api/shared/prerequisites/evm.ts
@@ -1,0 +1,26 @@
+import { BaseTransactionPrerequisite } from './base.js'
+import { EVM_APPROVE_TYPE } from './constants.js'
+
+/**
+ *  EVM Approve Prerequisite Type
+ *
+ */
+export interface EvmApprovePrerequisite extends BaseTransactionPrerequisite {
+  /** equals to "EVM_APPROVE" **/
+  type: typeof EVM_APPROVE_TYPE
+  /** The EVM-based blockchain that the approval is required on, e.g. ARBITRUM **/
+  blockChain: string
+  /** User's wallet address which must approve the token **/
+  wallet: string
+  /** The ERC-20 token contract address that must be approved **/
+  token: string
+  /** The contract address which will be allowed to spend the token **/
+  spender: string
+  /** The minimum required allowance, as an integer string in the token's smallest unit **/
+  amount: string
+}
+
+export const isEvmApprovePrerequisite = (
+  prerequisite: BaseTransactionPrerequisite,
+): prerequisite is EvmApprovePrerequisite =>
+  prerequisite.type === EVM_APPROVE_TYPE

--- a/packages/rango-types/src/api/shared/prerequisites/index.ts
+++ b/packages/rango-types/src/api/shared/prerequisites/index.ts
@@ -1,13 +1,19 @@
+import { EvmApprovePrerequisite } from './evm.js'
 import { StellarChangeTrustLinePrerequisite } from './stellar.js'
+import { TronApprovePrerequisite } from './tron.js'
 import { XrplChangeTrustLinePrerequisite } from './xrpl.js'
 
 export type TransactionPrerequisiteType =
   | StellarChangeTrustLinePrerequisite['type']
   | XrplChangeTrustLinePrerequisite['type']
+  | EvmApprovePrerequisite['type']
+  | TronApprovePrerequisite['type']
 
 export type TransactionPrerequisite =
   | XrplChangeTrustLinePrerequisite
   | StellarChangeTrustLinePrerequisite
+  | EvmApprovePrerequisite
+  | TronApprovePrerequisite
 
 export {
   XrplChangeTrustLinePrerequisite,
@@ -17,8 +23,12 @@ export {
   StellarChangeTrustLinePrerequisite,
   isStellarChangeTrustLinePrerequisite,
 } from './stellar.js'
+export { EvmApprovePrerequisite, isEvmApprovePrerequisite } from './evm.js'
+export { TronApprovePrerequisite, isTronApprovePrerequisite } from './tron.js'
 
 export {
   XRPL_CHANGE_TRUSTLINE_TYPE,
   STELLAR_CHANGE_TRUSTLINE_TYPE,
+  EVM_APPROVE_TYPE,
+  TRON_APPROVE_TYPE,
 } from './constants.js'

--- a/packages/rango-types/src/api/shared/prerequisites/tron.ts
+++ b/packages/rango-types/src/api/shared/prerequisites/tron.ts
@@ -1,0 +1,26 @@
+import { BaseTransactionPrerequisite } from './base.js'
+import { TRON_APPROVE_TYPE } from './constants.js'
+
+/**
+ *  Tron Approve Prerequisite Type
+ *
+ */
+export interface TronApprovePrerequisite extends BaseTransactionPrerequisite {
+  /** equals to "TRON_APPROVE" **/
+  type: typeof TRON_APPROVE_TYPE
+  /** equals to "TRON" **/
+  blockChain: string
+  /** User's wallet address which must approve the token (0x-hex form) **/
+  wallet: string
+  /** The TRC-20 token contract address that must be approved (0x-hex form) **/
+  token: string
+  /** The contract address which will be allowed to spend the token (0x-hex form) **/
+  spender: string
+  /** The minimum required allowance, as an integer string in the token's smallest unit **/
+  amount: string
+}
+
+export const isTronApprovePrerequisite = (
+  prerequisite: BaseTransactionPrerequisite,
+): prerequisite is TronApprovePrerequisite =>
+  prerequisite.type === TRON_APPROVE_TYPE

--- a/packages/rango-types/src/execution/index.ts
+++ b/packages/rango-types/src/execution/index.ts
@@ -146,7 +146,15 @@ export type PendingSwap = {
 export {
   isXrplChangeTrustLinePrerequisiteResult,
   isStellarChangeTrustLinePrerequisiteResult,
+  isEvmApprovePrerequisiteResult,
+  isTronApprovePrerequisiteResult,
   XrplChangeTrustLinePrerequisiteResult,
   StellarChangeTrustLinePrerequisiteResult,
+  EvmApprovePrerequisiteResult,
+  EvmExecutedApprovePrerequisiteResult,
+  EvmSkippedApprovePrerequisiteResult,
+  TronApprovePrerequisiteResult,
+  TronExecutedApprovePrerequisiteResult,
+  TronSkippedApprovePrerequisiteResult,
   TransactionPrerequisiteResult,
 } from './prerequisites.js'

--- a/packages/rango-types/src/execution/prerequisites.ts
+++ b/packages/rango-types/src/execution/prerequisites.ts
@@ -1,5 +1,7 @@
 import {
+  EVM_APPROVE_TYPE,
   STELLAR_CHANGE_TRUSTLINE_TYPE,
+  TRON_APPROVE_TYPE,
   XRPL_CHANGE_TRUSTLINE_TYPE,
   TransactionPrerequisiteType,
 } from '../api/shared/prerequisites/index.js'
@@ -65,6 +67,56 @@ export const isXrplChangeTrustLinePrerequisiteResult = (
 ): prerequisiteResult is XrplChangeTrustLinePrerequisiteResult =>
   prerequisiteResult.prerequisiteType === XRPL_CHANGE_TRUSTLINE_TYPE
 
+// Evm Approve Prerequisite Result
+
+export type EvmApprovePrerequisiteResultData = {
+  executedTransactionHash: string
+}
+
+export interface EvmExecutedApprovePrerequisiteResult extends BaseExecutedTransactionPrerequisiteResult {
+  prerequisiteType: typeof EVM_APPROVE_TYPE
+  data: EvmApprovePrerequisiteResultData
+}
+
+export interface EvmSkippedApprovePrerequisiteResult extends BaseSkippedTransactionPrerequisiteResult {
+  prerequisiteType: typeof EVM_APPROVE_TYPE
+}
+
+export type EvmApprovePrerequisiteResult =
+  | EvmExecutedApprovePrerequisiteResult
+  | EvmSkippedApprovePrerequisiteResult
+
+export const isEvmApprovePrerequisiteResult = (
+  prerequisiteResult: BaseTransactionPrerequisiteResult,
+): prerequisiteResult is EvmApprovePrerequisiteResult =>
+  prerequisiteResult.prerequisiteType === EVM_APPROVE_TYPE
+
+// Tron Approve Prerequisite Result
+
+export type TronApprovePrerequisiteResultData = {
+  executedTransactionHash: string
+}
+
+export interface TronExecutedApprovePrerequisiteResult extends BaseExecutedTransactionPrerequisiteResult {
+  prerequisiteType: typeof TRON_APPROVE_TYPE
+  data: TronApprovePrerequisiteResultData
+}
+
+export interface TronSkippedApprovePrerequisiteResult extends BaseSkippedTransactionPrerequisiteResult {
+  prerequisiteType: typeof TRON_APPROVE_TYPE
+}
+
+export type TronApprovePrerequisiteResult =
+  | TronExecutedApprovePrerequisiteResult
+  | TronSkippedApprovePrerequisiteResult
+
+export const isTronApprovePrerequisiteResult = (
+  prerequisiteResult: BaseTransactionPrerequisiteResult,
+): prerequisiteResult is TronApprovePrerequisiteResult =>
+  prerequisiteResult.prerequisiteType === TRON_APPROVE_TYPE
+
 export type TransactionPrerequisiteResult =
   | StellarChangeTrustLinePrerequisiteResult
   | XrplChangeTrustLinePrerequisiteResult
+  | EvmApprovePrerequisiteResult
+  | TronApprovePrerequisiteResult


### PR DESCRIPTION
# Summary

Adds `EVM_APPROVE` and `TRON_APPROVE` transaction prerequisite types to `rango-types` — the prerequisite types, their execution result types, and the type guards.

These back the frontend's migration of EVM/Tron token approvals from the legacy `isApprovalTx` + server `check-approval` flow to the unified `prerequisites` pattern (the same one already used for XRPL/Stellar trustlines): the backend returns approval requirements in a transaction's `prerequisites` list and the client handles the approval on-chain.

Additive and types-only — no changes to existing exports or behavior.

# How tested

- Package builds; the new types and guards resolve from the package root.
